### PR TITLE
[Feature/compensation]

### DIFF
--- a/AccountService/Dockerfile
+++ b/AccountService/Dockerfile
@@ -1,10 +1,4 @@
-FROM gradle:8.4-jdk21 AS build
-WORKDIR /workspace
-COPY . .
-RUN ./gradlew :AccountService:bootWar -x test --no-daemon
-
-FROM eclipse-temurin:21-jre
-WORKDIR /app
-COPY --from=build /workspace/AccountService/build/libs/*.war app.war
-EXPOSE 8081
-ENTRYPOINT ["java","-jar","app.war"]
+FROM eclipse-temurin:21-jdk
+ARG WAR_FILE=build/libs/*.war
+COPY ${WAR_FILE} app.war
+ENTRYPOINT ["java","-jar","/app.war"]

--- a/CartService/Dockerfile
+++ b/CartService/Dockerfile
@@ -1,10 +1,4 @@
-FROM gradle:8.4-jdk21 AS build
-WORKDIR /workspace
-COPY . .
-RUN ./gradlew :CartService:bootWar -x test --no-daemon
-
-FROM eclipse-temurin:21-jre
-WORKDIR /app
-COPY --from=build /workspace/CartService/build/libs/*.war app.war
-EXPOSE 8082
-ENTRYPOINT ["java","-jar","app.war"]
+FROM eclipse-temurin:17-jdk
+ARG WAR_FILE=build/libs/*.war
+COPY ${WAR_FILE} app.war
+ENTRYPOINT ["java","-jar","/app.war"]

--- a/CatalogService/Dockerfile
+++ b/CatalogService/Dockerfile
@@ -1,10 +1,4 @@
-FROM gradle:8.4-jdk21 AS build
-WORKDIR /workspace
-COPY . .
-RUN ./gradlew :CatalogService:bootWar -x test --no-daemon
-
-FROM eclipse-temurin:21-jre
-WORKDIR /app
-COPY --from=build /workspace/CatalogService/build/libs/*.war app.war
-EXPOSE 8083
-ENTRYPOINT ["java","-jar","app.war"]
+FROM eclipse-temurin:17-jdk
+ARG WAR_FILE=build/libs/*.war
+COPY ${WAR_FILE} app.war
+ENTRYPOINT ["java","-jar","/app.war"]

--- a/CatalogService/build.gradle
+++ b/CatalogService/build.gradle
@@ -4,8 +4,7 @@ archivesBaseName = 'jpetstore-catalog'
 
 dependencies {
     implementation project(':CommonLibrary')
-    implementation 'org.projectlombok:lombok:1.18.30'
-    implementation 'org.projectlombok:lombok:1.18.26'
+    compileOnly 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
     implementation 'org.springframework.kafka:spring-kafka:3.3.7'
     implementation 'net.devh:grpc-server-spring-boot-starter:3.1.0.RELEASE'

--- a/CatalogService/build.gradle
+++ b/CatalogService/build.gradle
@@ -9,5 +9,6 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
     implementation 'org.springframework.kafka:spring-kafka:3.3.7'
     implementation 'net.devh:grpc-server-spring-boot-starter:3.1.0.RELEASE'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 }
 

--- a/CatalogService/build.gradle
+++ b/CatalogService/build.gradle
@@ -5,6 +5,7 @@ archivesBaseName = 'jpetstore-catalog'
 dependencies {
     implementation project(':CommonLibrary')
     implementation 'org.projectlombok:lombok:1.18.30'
+    implementation 'org.projectlombok:lombok:1.18.26'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
     implementation 'org.springframework.kafka:spring-kafka:3.3.7'
     implementation 'net.devh:grpc-server-spring-boot-starter:3.1.0.RELEASE'

--- a/CatalogService/src/main/java/org/mybatis/jpetstore/catalog/controller/CatalogController.java
+++ b/CatalogService/src/main/java/org/mybatis/jpetstore/catalog/controller/CatalogController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.*;
 import java.util.HashMap;
 import java.util.List;
 
-
 @Controller
 @RequiredArgsConstructor
 public class CatalogController {

--- a/CatalogService/src/test/java/org/mybatis/jpetstore/catalog/service/RollbackIntegrationTest.java
+++ b/CatalogService/src/test/java/org/mybatis/jpetstore/catalog/service/RollbackIntegrationTest.java
@@ -1,0 +1,108 @@
+package org.mybatis.jpetstore.catalog.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mybatis.jpetstore.catalog.CatalogServiceApplication;
+import org.mybatis.jpetstore.catalog.controller.CatalogController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.ContainerTestUtils;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.listener.MessageListenerContainer;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Saga 패턴의 보상 트랜잭션 수신 측(Catalog Service) 통합 테스트입니다.
+ */
+@SpringBootTest(classes = CatalogServiceApplication.class, properties = {
+    "eureka.client.enabled=false",
+    "spring.cloud.discovery.enabled=false",
+    "spring.sql.init.mode=always",
+    "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,org.mybatis.jpetstore.common.config.CommonAutoConfiguration",
+    "spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer",
+    "spring.kafka.consumer.properties.spring.json.trusted.packages=*",
+    "spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer",
+    "kafka.bootstrap-servers=${spring.kafka.bootstrap-servers}",
+    "grpc.server.port=0"
+})
+@EmbeddedKafka(partitions = 1, topics = {"product_compensation"}, bootstrapServersProperty = "spring.kafka.bootstrap-servers")
+@ActiveProfiles("test")
+public class RollbackIntegrationTest {
+
+    @Autowired
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @MockitoSpyBean
+    private CatalogService catalogService;
+
+    @Autowired
+    private CatalogController catalogController;
+
+    @Autowired
+    private KafkaListenerEndpointRegistry kafkaListenerEndpointRegistry;
+
+    @Autowired
+    private EmbeddedKafkaBroker embeddedKafkaBroker;
+
+    @BeforeEach
+    public void setUp() {
+        for (MessageListenerContainer messageListenerContainer : kafkaListenerEndpointRegistry.getListenerContainers()) {
+            ContainerTestUtils.waitForAssignment(messageListenerContainer, embeddedKafkaBroker.getPartitionsPerTopic());
+        }
+    }
+
+    @Test
+    @DisplayName("보상 트랜잭션 통합 테스트: Catalog 서비스는 Kafka 보상 이벤트를 받으면 실제 DB 재고를 복구해야 한다")
+    void verifyCatalogRollbackByKafkaEvent() {
+        // Given: 보상 이벤트 데이터 (아이템 EST-1, 수량 10개 복구)
+        Map<String, Object> data = new HashMap<>();
+        data.put("EST-1", 10);
+
+        // 테스트 시작 전 EST-1 의 현재 재고 확인 (데이터로드 SQL 에 의해 10000개로 초기화됨)
+        Integer initialQuantity = catalogService.getItemQuantity("EST-1");
+        assertNotNull(initialQuantity);
+        System.out.println("=== [TEST] Initial DB Quantity for EST-1: " + initialQuantity + " ===");
+
+        // When: 실제 Kafka 토픽으로 메시지 전송
+        System.out.println("=== [TEST] SENDING COMPENSATION EVENT TO EMBEDDED KAFKA ===");
+        kafkaTemplate.send("product_compensation", data);
+        kafkaTemplate.flush();
+
+        // Then: CatalogController의 @KafkaListener가 동작하여 catalogService.rollbackInventory를 호출하는지 대기
+        verify(catalogService, timeout(15000).times(1)).rollbackInventory(any());
+        
+        // Kafka 메시지 처리로 인해 트랜잭션이 커밋되는 시간을 약간 대기 (필요시)
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        // DB 재고가 실제로 복구되었는지 확인
+        Integer updatedQuantity = catalogService.getItemQuantity("EST-1");
+        System.out.println("=== [TEST] Updated DB Quantity for EST-1: " + updatedQuantity + " ===");
+        
+        assertEquals(initialQuantity + 10, updatedQuantity);
+        
+        System.out.println("=== [TEST] VERIFIED: Catalog Service DB Rollback Triggered and Executed by REAL Kafka Event! ===");
+    }
+}

--- a/DiscoveryServer/Dockerfile
+++ b/DiscoveryServer/Dockerfile
@@ -1,10 +1,4 @@
-FROM gradle:8.4-jdk21 AS build
-WORKDIR /workspace
-COPY . .
-RUN ./gradlew :DiscoveryServer:bootJar -x test --no-daemon
-
-FROM eclipse-temurin:21-jre
-WORKDIR /app
-COPY --from=build /workspace/DiscoveryServer/build/libs/*.jar app.jar
-EXPOSE 8761
-ENTRYPOINT ["java","-jar","app.jar"]
+FROM eclipse-temurin:17-jdk
+ARG WAR_FILE=build/libs/*.war
+COPY ${WAR_FILE} app.war
+ENTRYPOINT ["java","-jar","/app.war"]

--- a/GatewayService/Dockerfile
+++ b/GatewayService/Dockerfile
@@ -1,10 +1,4 @@
-FROM gradle:8.4-jdk21 AS build
-WORKDIR /workspace
-COPY . .
-RUN ./gradlew :GatewayService:bootJar -x test --no-daemon
-
-FROM eclipse-temurin:21-jre
-WORKDIR /app
-COPY --from=build /workspace/GatewayService/build/libs/*.jar app.jar
-EXPOSE 8880
-ENTRYPOINT ["java","-jar","app.jar"]
+FROM eclipse-temurin:17-jdk
+ARG WAR_FILE=build/libs/*.war
+COPY ${WAR_FILE} app.war
+ENTRYPOINT ["java","-jar","/app.war"]

--- a/OrderService/Dockerfile
+++ b/OrderService/Dockerfile
@@ -1,10 +1,4 @@
-FROM gradle:8.4-jdk21 AS build
-WORKDIR /workspace
-COPY . .
-RUN ./gradlew :OrderService:bootWar -x test --no-daemon
-
-FROM eclipse-temurin:21-jre
-WORKDIR /app
-COPY --from=build /workspace/OrderService/build/libs/*.war app.war
-EXPOSE 8084
-ENTRYPOINT ["java","-jar","app.war"]
+FROM eclipse-temurin:17-jdk
+ARG WAR_FILE=build/libs/*.war
+COPY ${WAR_FILE} app.war
+ENTRYPOINT ["java","-jar","/app.war"]

--- a/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
+++ b/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
@@ -31,6 +31,7 @@ import org.mybatis.jpetstore.common.grpc.CatalogGrpcClient;
 import org.mybatis.jpetstore.order.repository.LineItemRepository;
 import org.mybatis.jpetstore.order.repository.OrderRepository;
 import org.mybatis.jpetstore.order.repository.SequenceRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -64,6 +65,15 @@ public class OrderService {
   // 첫 주문 등의 이유로 지난 주문에 대한 내역이 없는 상태
   private static final String UNPROCESSED = "unprocessed";
   private static final String COMPENSATION_TOPIC = "product_compensation";
+
+  @Value("${order.chaos.force-persist-failure:false}")
+  private boolean forcePersistFailure;
+
+  @Value("${order.chaos.skip-compensation-on-persist-failure:false}")
+  private boolean skipCompensationOnPersistFailure;
+
+  @Value("${order.chaos.check-inventory-inconsistency-on-failure:true}")
+  private boolean checkInventoryInconsistencyOnFailure;
 
 
   /**
@@ -264,14 +274,43 @@ public class OrderService {
   private void persistOrderOrCompensate(Order order, Map<String, Object> incrementPerItem)
       throws OrderFailException {
     try {
+      if (forcePersistFailure) {
+        throw new IllegalStateException("Chaos mode: forced order persistence failure");
+      }
       orderRepository.insert(order);
       orderRepository.updateStatus(new OrderRetryStatus(order.getOrderId(), SUCCESS));
     } catch (Exception e) {
-      log.error("Order persistence failed. Publishing compensation transaction. orderId={}",
+      log.error("Order persistence failed. orderId={}",
           order.getOrderId(), e);
-      kafkaTemplate.send(COMPENSATION_TOPIC, incrementPerItem);
+
+      if (skipCompensationOnPersistFailure) {
+        log.error("Chaos mode: skipping compensation transaction on failure. orderId={}",
+            order.getOrderId());
+      } else {
+        kafkaTemplate.send(COMPENSATION_TOPIC, incrementPerItem);
+      }
+
+      logPotentialInventoryInconsistency(order.getOrderId());
       orderRepository.updateStatus(new OrderRetryStatus(order.getOrderId(), FAIL));
-      throw new OrderFailException("주문 저장 실패로 보상 트랜잭션이 발행되었습니다.");
+      throw new OrderFailException("주문 저장에 실패했습니다.");
+    }
+  }
+
+  private void logPotentialInventoryInconsistency(int orderId) {
+    if (!checkInventoryInconsistencyOnFailure) {
+      return;
+    }
+
+    try {
+      boolean inventoryCommitSucceeded = catalogGrpcClient.isInventoryUpdateCommitSuccess(orderId);
+      if (inventoryCommitSucceeded) {
+        log.error("INVENTORY_INCONSISTENCY_DETECTED - inventory was already committed but order failed. orderId={}",
+            orderId);
+      } else {
+        log.info("Inventory update was not committed, no inconsistency detected. orderId={}", orderId);
+      }
+    } catch (Exception exception) {
+      log.warn("Failed to verify potential inventory inconsistency. orderId={}", orderId, exception);
     }
   }
 

--- a/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
+++ b/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
@@ -168,43 +168,43 @@ public class OrderService {
    *
    * @param order 생성할 주문
    */
+
+  // TODO : 그리고 멱등성에 대한 UUID 키는 프론트에서 주는것. ORDER_ID가 아니다.프론트에서 사용자가 동일한 주문을 여러번 요청하는치 판단하고, header로 UUID 키를 주는게 맞다.
+  // TODO : 로직이 너무 복잡하다. 리팩토링 필요
   @Transactional
   public void insertOrder(Order order, HttpSession session) throws OrderFailException, RetryUnknownException {
 
-      Optional<OrderRetryStatus> orderRetryStatus = orderRepository.findStatus(order.getOrderId());
+    Optional<OrderRetryStatus> orderRetryStatus = orderRepository.findStatus(order.getOrderId());
 
-      if (!orderRetryStatus.isPresent()){
-          orderRepository.insertStatus(new OrderRetryStatus(order.getOrderId(), UNPROCESSED));
-          orderRetryStatus = orderRepository.findStatus(order.getOrderId());
-      }
+    if (!orderRetryStatus.isPresent()) {
+      orderRepository.insertStatus(new OrderRetryStatus(order.getOrderId(), UNPROCESSED));
+      orderRetryStatus = orderRepository.findStatus(order.getOrderId());
+    }
 
-      if(orderRetryStatus.get().getStatus().equals(SUCCESS)){
-        return;
-      }
+    if (orderRetryStatus.get().getStatus().equals(SUCCESS)) {
+      return;
+    }
 
-      // Unknown 재요청 실패한 경우 -> 재요청 필요
-      if (orderRetryStatus.get().getStatus().equals(UNKNOWN)){
-        updateCommitSuccessCheck(order);
-      }
+    // Unknown 재요청 실패한 경우 -> 재요청 필요
+    if (orderRetryStatus.get().getStatus().equals(UNKNOWN)) {
+      updateCommitSuccessCheck(order);
+    }
 
     Map<String, Object> incrementPerItem = getIncrementAndItemsParam(order);
-    boolean resp = catalogGrpcClient.updateInventoryQuantity(incrementPerItem,order.getOrderId());
+    boolean resp = catalogGrpcClient.updateInventoryQuantity(incrementPerItem, order.getOrderId());
 
     // 즉시 재요청 : 5xx error, Time-out 발생한 경우 (비정상 실패)
     if (!resp) {
       updateCommitSuccessCheck(order);
     }
 
-    try{
-      orderRepository.insert(order);
-    }catch (Exception e){
-      kafkaTemplate.send("product_compensation",incrementPerItem);
+    try {
+      orderRepository.insert(
+          order); // TODO : commit이 됐으니까 보상을 하지 않겠다는건 말이 안됨. 어쨌든 error가 발생한 상황이고 다른 지점에 문제가 발생했을 수 있기 때문에 보상을 하지 않더라도 주문을 로직을 완료처리해서는 안됨
+    } catch (Exception e) {
+      kafkaTemplate.send("product_compensation", incrementPerItem);
+      orderRepository.updateStatus(new OrderRetryStatus(order.getOrderId(), SUCCESS));
     }
-
-
-
-
-    orderRepository.updateStatus(new OrderRetryStatus(order.getOrderId(), SUCCESS));
   }
 
   private static Map<String, Object> getIncrementAndItemsParam(Order order) {

--- a/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
+++ b/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
@@ -169,7 +169,7 @@ public class OrderService {
    * @param order 생성할 주문
    */
 
-  // TODO : 그리고 멱등성에 대한 UUID 키는 프론트에서 주는것. ORDER_ID가 아니다.프론트에서 사용자가 동일한 주문을 여러번 요청하는치 판단하고, header로 UUID 키를 주는게 맞다.
+  // TODO : 그리고 멱등성에 처리 방식에 대해서도 재고민해 볼 필요가 있을 것 같다.
   // TODO : 로직이 너무 복잡하다. 리팩토링 필요
   @Transactional
   public void insertOrder(Order order, HttpSession session) throws OrderFailException, RetryUnknownException {

--- a/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
+++ b/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
@@ -174,7 +174,7 @@ public class OrderService {
   @Transactional
   public void insertOrder(Order order, HttpSession session) throws OrderFailException, RetryUnknownException {
 
-    Optional<OrderRetryStatus> orderRetryStatus = orderRepository.findStatus(order.getOrderId());
+    Optional<OrderRetryStatus> orderRetryStatus = orderRepository.findStatus(order.getOrderId()); // 재요청 상태 조회를 orderID로 하면 안된다고 생각한다. -> 프론트에서 주는 UUID 키로 해야함
 
     if (!orderRetryStatus.isPresent()) {
       orderRepository.insertStatus(new OrderRetryStatus(order.getOrderId(), UNPROCESSED));
@@ -188,9 +188,9 @@ public class OrderService {
     // Unknown 재요청 실패한 경우 -> 재요청 필요
     if (orderRetryStatus.get().getStatus().equals(UNKNOWN)) {
       updateCommitSuccessCheck(order);
-    }
+    } // TODO : 분기가 너무 많다.
 
-    Map<String, Object> incrementPerItem = getIncrementAndItemsParam(order);
+    Map<String, Object> incrementPerItem = getIncrementAndItemsParam(order); // TODO : item에 대한 재고와 수량만 넘기면 되는것이 맞는지 재고민
     boolean resp = catalogGrpcClient.updateInventoryQuantity(incrementPerItem, order.getOrderId());
 
     // 즉시 재요청 : 5xx error, Time-out 발생한 경우 (비정상 실패)

--- a/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
+++ b/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
@@ -63,6 +63,7 @@ public class OrderService {
   private static final String FAIL = "fail";
   // 첫 주문 등의 이유로 지난 주문에 대한 내역이 없는 상태
   private static final String UNPROCESSED = "unprocessed";
+  private static final String COMPENSATION_TOPIC = "product_compensation";
 
 
   /**
@@ -170,41 +171,18 @@ public class OrderService {
    */
 
   // TODO : 그리고 멱등성에 처리 방식에 대해서도 재고민해 볼 필요가 있을 것 같다.
-  // TODO : 로직이 너무 복잡하다. 리팩토링 필요
   @Transactional
   public void insertOrder(Order order, HttpSession session) throws OrderFailException, RetryUnknownException {
-
-    Optional<OrderRetryStatus> orderRetryStatus = orderRepository.findStatus(order.getOrderId()); // 재요청 상태 조회를 orderID로 하면 안된다고 생각한다. -> 프론트에서 주는 UUID 키로 해야함
-
-    if (!orderRetryStatus.isPresent()) {
-      orderRepository.insertStatus(new OrderRetryStatus(order.getOrderId(), UNPROCESSED));
-      orderRetryStatus = orderRepository.findStatus(order.getOrderId());
-    }
-
-    if (orderRetryStatus.get().getStatus().equals(SUCCESS)) {
+    OrderRetryStatus retryStatus = getOrCreateRetryStatus(order.getOrderId());
+    if (isOrderAlreadySucceeded(retryStatus)) {
       return;
     }
 
-    // Unknown 재요청 실패한 경우 -> 재요청 필요
-    if (orderRetryStatus.get().getStatus().equals(UNKNOWN)) {
-      updateCommitSuccessCheck(order);
-    } // TODO : 분기가 너무 많다.
+    ensureUnknownStateIsRecoverable(retryStatus, order);
 
-    Map<String, Object> incrementPerItem = getIncrementAndItemsParam(order); // TODO : item에 대한 재고와 수량만 넘기면 되는것이 맞는지 재고민
-    boolean resp = catalogGrpcClient.updateInventoryQuantity(incrementPerItem, order.getOrderId());
-
-    // 즉시 재요청 : 5xx error, Time-out 발생한 경우 (비정상 실패)
-    if (!resp) {
-      updateCommitSuccessCheck(order);
-    }
-
-    try {
-      orderRepository.insert(
-          order); // TODO : commit이 됐으니까 보상을 하지 않겠다는건 말이 안됨. 어쨌든 error가 발생한 상황이고 다른 지점에 문제가 발생했을 수 있기 때문에 보상을 하지 않더라도 주문을 로직을 완료처리해서는 안됨
-    } catch (Exception e) {
-      kafkaTemplate.send("product_compensation", incrementPerItem);
-      orderRepository.updateStatus(new OrderRetryStatus(order.getOrderId(), SUCCESS));
-    }
+    Map<String, Object> incrementPerItem = getIncrementAndItemsParam(order);
+    updateInventoryOrThrow(order, incrementPerItem);
+    persistOrderOrCompensate(order, incrementPerItem);
   }
 
   private static Map<String, Object> getIncrementAndItemsParam(Order order) {
@@ -226,12 +204,15 @@ public class OrderService {
       // 즉시 재요청 - 수량 변경 commit 성공 여부 확인
       boolean isCommitSuccess = catalogGrpcClient.isInventoryUpdateCommitSuccess(sessionOrder.getOrderId());
 
-      if (!isCommitSuccess) {
-        // fail : Known_case2 : commit 실패한 경우 -> 실패 처리
-        log.info("Known_case2_commitFail");
-        orderRepository.updateStatus(new OrderRetryStatus(sessionOrder.getOrderId(), FAIL));
-        throw new OrderFailException("주문 실패");
+      // commit 성공 여부와 무관하게 현재 주문은 실패 처리하고 보상 트랜잭션 발행
+      if (isCommitSuccess) {
+        log.info("Known_case1_commitSuccess_compensationNeeded");
+        publishCompensation(sessionOrder);
       }
+
+      log.info("Known_case2_commitFail");
+      orderRepository.updateStatus(new OrderRetryStatus(sessionOrder.getOrderId(), FAIL));
+      throw new OrderFailException("주문 실패");
 
     } catch(HttpServerErrorException serverError){
         // Unknown : 즉시 재요청에 server Error 발생, 트랜잭션 커밋 성공 여부를 알 수 없는 경우
@@ -245,7 +226,53 @@ public class OrderService {
         orderRepository.updateStatus(new OrderRetryStatus(sessionOrder.getOrderId(), UNKNOWN));
         throw new RetryUnknownException("리소스 접근 예외 발생 - time out");
       }
-    log.info("문제 없음");
+  }
+
+  private OrderRetryStatus getOrCreateRetryStatus(int orderId) {
+    return orderRepository.findStatus(orderId)
+        .orElseGet(() -> {
+          orderRepository.insertStatus(new OrderRetryStatus(orderId, UNPROCESSED));
+          return new OrderRetryStatus(orderId, UNPROCESSED);
+        });
+  }
+
+  private boolean isOrderAlreadySucceeded(OrderRetryStatus retryStatus) {
+    return SUCCESS.equals(retryStatus.getStatus());
+  }
+
+  private void ensureUnknownStateIsRecoverable(OrderRetryStatus retryStatus, Order order)
+      throws OrderFailException, RetryUnknownException {
+    if (UNKNOWN.equals(retryStatus.getStatus())) {
+      updateCommitSuccessCheck(order);
+    }
+  }
+
+  private void updateInventoryOrThrow(Order order, Map<String, Object> incrementPerItem)
+      throws OrderFailException, RetryUnknownException {
+    boolean inventoryUpdated = catalogGrpcClient.updateInventoryQuantity(incrementPerItem, order.getOrderId());
+    if (!inventoryUpdated) {
+      updateCommitSuccessCheck(order);
+    }
+  }
+
+
+  private void publishCompensation(Order order) {
+    Map<String, Object> incrementPerItem = getIncrementAndItemsParam(order);
+    kafkaTemplate.send(COMPENSATION_TOPIC, incrementPerItem);
+  }
+
+  private void persistOrderOrCompensate(Order order, Map<String, Object> incrementPerItem)
+      throws OrderFailException {
+    try {
+      orderRepository.insert(order);
+      orderRepository.updateStatus(new OrderRetryStatus(order.getOrderId(), SUCCESS));
+    } catch (Exception e) {
+      log.error("Order persistence failed. Publishing compensation transaction. orderId={}",
+          order.getOrderId(), e);
+      kafkaTemplate.send(COMPENSATION_TOPIC, incrementPerItem);
+      orderRepository.updateStatus(new OrderRetryStatus(order.getOrderId(), FAIL));
+      throw new OrderFailException("주문 저장 실패로 보상 트랜잭션이 발행되었습니다.");
+    }
   }
 
   /**

--- a/OrderService/src/main/resources/application.yml
+++ b/OrderService/src/main/resources/application.yml
@@ -51,3 +51,8 @@ eureka:
   instance:
     prefer-ip-address: true
     instance-id: ${spring.application.name}:${server.port}
+order:
+  chaos:
+    force-persist-failure: ${ORDER_CHAOS_FORCE_PERSIST_FAILURE:false}
+    skip-compensation-on-persist-failure: ${ORDER_CHAOS_SKIP_COMPENSATION_ON_PERSIST_FAILURE:false}
+    check-inventory-inconsistency-on-failure: ${ORDER_CHAOS_CHECK_INVENTORY_INCONSISTENCY_ON_FAILURE:true}

--- a/OrderService/src/test/java/org/mybatis/jpetstore/order/service/CompensationIntegrationTest.java
+++ b/OrderService/src/test/java/org/mybatis/jpetstore/order/service/CompensationIntegrationTest.java
@@ -1,0 +1,96 @@
+package org.mybatis.jpetstore.order.service;
+
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mybatis.jpetstore.common.domain.LineItem;
+import org.mybatis.jpetstore.common.domain.Order;
+import org.mybatis.jpetstore.common.grpc.CatalogGrpcClient;
+import org.mybatis.jpetstore.order.domain.OrderRetryStatus;
+import org.mybatis.jpetstore.order.exception.OrderFailException;
+import org.mybatis.jpetstore.order.repository.LineItemRepository;
+import org.mybatis.jpetstore.order.repository.OrderRepository;
+import org.mybatis.jpetstore.order.repository.SequenceRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(properties = {
+    "spring.session.store-type=none",
+    "eureka.client.enabled=false",
+    "spring.cloud.discovery.enabled=false",
+    "spring.sql.init.mode=never",
+    "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,org.mybatis.jpetstore.common.config.CommonAutoConfiguration",
+    "spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer"
+})
+@EmbeddedKafka(partitions = 1, topics = {"product_compensation"}, bootstrapServersProperty = "spring.kafka.bootstrap-servers")
+@ActiveProfiles("test")
+public class CompensationIntegrationTest {
+
+    @Autowired
+    private OrderService orderService;
+
+    @MockitoBean
+    private OrderRepository orderRepository;
+    @MockitoBean
+    private SequenceRepository sequenceRepository;
+    @MockitoBean
+    private LineItemRepository lineItemRepository;
+    @MockitoBean
+    private CatalogGrpcClient catalogGrpcClient;
+    @MockitoBean
+    private HttpSession session;
+
+    // KafkaTemplate을 Spy로 등록하여 실제 전송 호출을 캡처
+    @MockitoSpyBean
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Test
+    @DisplayName("보상 트랜잭션 통합 테스트: 주문 저장 실패 시 KafkaTemplate.send 가 실제로 호출되어야 한다")
+    void verifyKafkaTemplateCallOnFailure() throws Exception {
+        // Given
+        Order order = new Order();
+        order.setOrderId(7777);
+        List<LineItem> lineItems = new ArrayList<>();
+        LineItem item = new LineItem();
+        item.setItemId("EST-1");
+        item.setQuantity(3);
+        lineItems.add(item);
+        order.setLineItems(lineItems);
+
+        when(catalogGrpcClient.updateInventoryQuantity(any(), anyInt())).thenReturn(true);
+        when(orderRepository.findStatus(anyInt())).thenReturn(Optional.of(new OrderRetryStatus(7777, "unprocessed")));
+        
+        doThrow(new RuntimeException("DB_SAVE_ERROR")).when(orderRepository).insert(any(Order.class));
+
+        // When
+        try {
+            orderService.insertOrder(order, session);
+        } catch (OrderFailException e) {
+            // expected
+        }
+
+        // Then: KafkaTemplate.send 가 올바른 토픽과 데이터로 호출되었는지 확인
+        // Map 형태의 데이터가 전송되므로 ArgumentMatcher 사용
+        verify(kafkaTemplate, timeout(5000).times(1)).send(eq("product_compensation"), argThat(map -> {
+            Map<String, Object> param = (Map<String, Object>) map;
+            return param.containsKey("EST-1") && param.get("EST-1").toString().equals("3");
+        }));
+        
+        System.out.println("=== VERIFIED: KafkaTemplate.send was called with correct compensation data! ===");
+    }
+}

--- a/OrderService/src/test/java/org/mybatis/jpetstore/order/service/OrderServiceTest.java
+++ b/OrderService/src/test/java/org/mybatis/jpetstore/order/service/OrderServiceTest.java
@@ -1,0 +1,69 @@
+package org.mybatis.jpetstore.order.service;
+
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mybatis.jpetstore.common.domain.Order;
+import org.mybatis.jpetstore.common.grpc.CatalogGrpcClient;
+import org.mybatis.jpetstore.order.domain.OrderRetryStatus;
+import org.mybatis.jpetstore.order.exception.OrderFailException;
+import org.mybatis.jpetstore.order.exception.RetryUnknownException;
+import org.mybatis.jpetstore.order.repository.OrderRepository;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Mock
+    private CatalogGrpcClient catalogGrpcClient;
+
+    @Mock
+    private HttpSession session;
+
+    @InjectMocks
+    private OrderService orderService;
+
+    @Test
+    @DisplayName("주문 저장 실패 시 Kafka 보상 메시지가 발행되는지 확인")
+    void shouldSendKafkaMessageWhenOrderInsertFails() throws OrderFailException, RetryUnknownException {
+        // 1. 테스트 데이터 준비
+        Order order = new Order();
+        order.setOrderId(1001);
+        order.setLineItems(new java.util.ArrayList<>());
+
+        // 2. Mock 설정
+        when(orderRepository.findStatus(anyInt()))
+            .thenReturn(Optional.empty())
+            .thenReturn(Optional.of(new OrderRetryStatus(1001, "unprocessed")));
+        
+        when(catalogGrpcClient.updateInventoryQuantity(any(), anyInt())).thenReturn(true);
+
+        // 핵심: orderRepository.insert 호출 시 강제로 예외 발생
+        doThrow(new RuntimeException("DB Insert Error")).when(orderRepository).insert(any(Order.class));
+
+        // 3. 테스트 실행
+        orderService.insertOrder(order, session);
+
+        // 4. 검증: kafkaTemplate.send가 "product_compensation" 토픽으로 호출되었는지 확인
+        verify(kafkaTemplate, times(1)).send(eq("product_compensation"), any());
+        
+        // 추가 검증: 상태가 success로 업데이트 되었는지 확인
+        verify(orderRepository, times(1)).updateStatus(argThat(status -> status.getStatus().equals("success")));
+    }
+}

--- a/OrderService/src/test/java/org/mybatis/jpetstore/order/service/OrderServiceTest.java
+++ b/OrderService/src/test/java/org/mybatis/jpetstore/order/service/OrderServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -40,8 +41,8 @@ class OrderServiceTest {
     private OrderService orderService;
 
     @Test
-    @DisplayName("주문 저장 실패 시 Kafka 보상 메시지가 발행되는지 확인")
-    void shouldSendKafkaMessageWhenOrderInsertFails() throws OrderFailException, RetryUnknownException {
+    @DisplayName("주문 저장 실패 시 Kafka 보상 메시지를 발행하고 실패 처리한다")
+    void shouldCompensateAndFailWhenOrderInsertFails() throws RetryUnknownException {
         // 1. 테스트 데이터 준비
         Order order = new Order();
         order.setOrderId(1001);
@@ -49,8 +50,7 @@ class OrderServiceTest {
 
         // 2. Mock 설정
         when(orderRepository.findStatus(anyInt()))
-            .thenReturn(Optional.empty())
-            .thenReturn(Optional.of(new OrderRetryStatus(1001, "unprocessed")));
+            .thenReturn(Optional.empty());
         
         when(catalogGrpcClient.updateInventoryQuantity(any(), anyInt())).thenReturn(true);
 
@@ -58,12 +58,30 @@ class OrderServiceTest {
         doThrow(new RuntimeException("DB Insert Error")).when(orderRepository).insert(any(Order.class));
 
         // 3. 테스트 실행
-        orderService.insertOrder(order, session);
+        assertThrows(OrderFailException.class, () -> orderService.insertOrder(order, session));
 
         // 4. 검증: kafkaTemplate.send가 "product_compensation" 토픽으로 호출되었는지 확인
         verify(kafkaTemplate, times(1)).send(eq("product_compensation"), any());
         
-        // 추가 검증: 상태가 success로 업데이트 되었는지 확인
-        verify(orderRepository, times(1)).updateStatus(argThat(status -> status.getStatus().equals("success")));
+        // 추가 검증: 상태가 fail로 업데이트 되었는지 확인
+        verify(orderRepository, times(1)).updateStatus(argThat(status -> status.getStatus().equals("fail")));
     }
+
+    @Test
+    @DisplayName("inventory commit 성공 확인 시에도 보상 트랜잭션을 발행하고 실패 처리한다")
+    void shouldCompensateAndFailWhenCommitSuccessIsConfirmed() throws RetryUnknownException {
+        Order order = new Order();
+        order.setOrderId(2002);
+        order.setLineItems(new java.util.ArrayList<>());
+
+        when(orderRepository.findStatus(anyInt())).thenReturn(Optional.of(new OrderRetryStatus(2002, "unknown")));
+        when(catalogGrpcClient.isInventoryUpdateCommitSuccess(2002)).thenReturn(true);
+
+        assertThrows(OrderFailException.class, () -> orderService.insertOrder(order, session));
+
+        verify(kafkaTemplate, times(1)).send(eq("product_compensation"), any());
+        verify(orderRepository, times(1)).updateStatus(argThat(status -> status.getStatus().equals("fail")));
+        verify(orderRepository, never()).insert(any(Order.class));
+    }
+
 }

--- a/OrderService/src/test/java/org/mybatis/jpetstore/order/service/OrderServiceTest.java
+++ b/OrderService/src/test/java/org/mybatis/jpetstore/order/service/OrderServiceTest.java
@@ -14,11 +14,13 @@ import org.mybatis.jpetstore.order.exception.OrderFailException;
 import org.mybatis.jpetstore.order.exception.RetryUnknownException;
 import org.mybatis.jpetstore.order.repository.OrderRepository;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -43,27 +45,17 @@ class OrderServiceTest {
     @Test
     @DisplayName("주문 저장 실패 시 Kafka 보상 메시지를 발행하고 실패 처리한다")
     void shouldCompensateAndFailWhenOrderInsertFails() throws RetryUnknownException {
-        // 1. 테스트 데이터 준비
         Order order = new Order();
         order.setOrderId(1001);
         order.setLineItems(new java.util.ArrayList<>());
 
-        // 2. Mock 설정
-        when(orderRepository.findStatus(anyInt()))
-            .thenReturn(Optional.empty());
-        
+        when(orderRepository.findStatus(anyInt())).thenReturn(Optional.empty());
         when(catalogGrpcClient.updateInventoryQuantity(any(), anyInt())).thenReturn(true);
-
-        // 핵심: orderRepository.insert 호출 시 강제로 예외 발생
         doThrow(new RuntimeException("DB Insert Error")).when(orderRepository).insert(any(Order.class));
 
-        // 3. 테스트 실행
         assertThrows(OrderFailException.class, () -> orderService.insertOrder(order, session));
 
-        // 4. 검증: kafkaTemplate.send가 "product_compensation" 토픽으로 호출되었는지 확인
         verify(kafkaTemplate, times(1)).send(eq("product_compensation"), any());
-        
-        // 추가 검증: 상태가 fail로 업데이트 되었는지 확인
         verify(orderRepository, times(1)).updateStatus(argThat(status -> status.getStatus().equals("fail")));
     }
 
@@ -84,4 +76,43 @@ class OrderServiceTest {
         verify(orderRepository, never()).insert(any(Order.class));
     }
 
+    @Test
+    @DisplayName("Chaos 모드에서 주문 저장 실패를 강제로 발생시키고 보상 트랜잭션을 발행한다")
+    void shouldForcePersistFailureAndPublishCompensationInChaosMode() {
+        Order order = new Order();
+        order.setOrderId(3003);
+        order.setLineItems(new java.util.ArrayList<>());
+
+        ReflectionTestUtils.setField(orderService, "forcePersistFailure", true);
+
+        when(orderRepository.findStatus(anyInt())).thenReturn(Optional.empty());
+        when(catalogGrpcClient.updateInventoryQuantity(any(), anyInt())).thenReturn(true);
+
+        assertThrows(OrderFailException.class, () -> orderService.insertOrder(order, session));
+
+        verify(kafkaTemplate, times(1)).send(eq("product_compensation"), any());
+        verify(orderRepository, never()).insert(any(Order.class));
+        verify(orderRepository, times(1)).updateStatus(argThat(status -> status.getStatus().equals("fail")));
+    }
+
+    @Test
+    @DisplayName("Chaos 모드에서 보상 트랜잭션을 생략하면 Kafka 보상 메시지를 발행하지 않는다")
+    void shouldSkipCompensationWhenChaosFlagIsEnabled() {
+        Order order = new Order();
+        order.setOrderId(4004);
+        order.setLineItems(new java.util.ArrayList<>());
+
+        ReflectionTestUtils.setField(orderService, "forcePersistFailure", true);
+        ReflectionTestUtils.setField(orderService, "skipCompensationOnPersistFailure", true);
+
+        when(orderRepository.findStatus(anyInt())).thenReturn(Optional.empty());
+        when(catalogGrpcClient.updateInventoryQuantity(any(), anyInt())).thenReturn(true);
+        when(catalogGrpcClient.isInventoryUpdateCommitSuccess(4004)).thenReturn(true);
+
+        assertThrows(OrderFailException.class, () -> orderService.insertOrder(order, session));
+
+        verify(kafkaTemplate, never()).send(eq("product_compensation"), any());
+        verify(catalogGrpcClient, times(1)).isInventoryUpdateCommitSuccess(4004);
+        verify(orderRepository, times(1)).updateStatus(argThat(status -> status.getStatus().equals("fail")));
+    }
 }

--- a/README.md
+++ b/README.md
@@ -21,3 +21,18 @@
 - [ ] 서비스 간의 세션 공유가 적절한가? 단일 장애 지점이 되지는 않는가?
 - [ ] 다른 서비스의 로직을 참고하는 상황에서 N+1 문제가 발생하지는 않는가? API 통신이기 때문에 호출량이 많아지면 엄청난 지연이 발생 가능하다.
 - [ ] 현재와 같이 SSR일 경우에 다른 서비스의 데이터들을 조합까지 한 후 뷰를 반환하게 되면 응답 속도가 SPA에 비해 느려지지 않는가? 그렇다면 뷰를 분리할 것인가?
+
+
+## Kafka 보상 트랜잭션 Chaos 테스트 (OrderService)
+- `ORDER_CHAOS_FORCE_PERSIST_FAILURE=true` : 재고 차감 이후 Order 저장 단계에서 의도적으로 실패를 발생시킨다.
+- `ORDER_CHAOS_SKIP_COMPENSATION_ON_PERSIST_FAILURE=true` : 저장 실패 시 Kafka 보상 메시지 발행을 생략한다(재고 불일치 재현용).
+- `ORDER_CHAOS_CHECK_INVENTORY_INCONSISTENCY_ON_FAILURE=true` : 실패 시 `isInventoryUpdateCommitSuccess`를 재조회하여 불일치 여부를 로그로 남긴다.
+
+예시:
+```bash
+ORDER_CHAOS_FORCE_PERSIST_FAILURE=true \
+ORDER_CHAOS_SKIP_COMPENSATION_ON_PERSIST_FAILURE=false \
+./gradlew :OrderService:bootRun
+```
+
+보상 비활성화 시에는 OrderService 로그에 `INVENTORY_INCONSISTENCY_DETECTED`가 출력되는지 확인한다.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.5.3' apply false
+    id 'org.springframework.boot' version '3.3.7' apply false
     id 'io.spring.dependency-management' version '1.1.7' apply false
     id 'com.google.protobuf' version '0.9.4' apply false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,10 @@ subprojects {
     dependencies {
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
     }
+
+    test {
+        useJUnitPlatform()
+    }
 }
 
 configure(subprojects.findAll { it.name != commonLibName }) {

--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -7,9 +7,6 @@ services:
       - "80:80"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
-#    # Linux에서 host.docker.internal 사용을 위해:
-#    extra_hosts:
-#      - "host.docker.internal:host-gateway"
   redis:
     image: redis:alpine
     container_name: redis
@@ -17,12 +14,68 @@ services:
       - "6379:6379"
     volumes:
       - redis-data:/data
-
   kafka:
     image: apache/kafka:4.0.0
     container_name: kafka
     ports:
       - "9092:9092"
+  kafdrop:
+    image: obsidiandynamics/kafdrop
+    container_name: kafdrop
+    ports:
+      - "9000:9000"
+    environment:
+      KAFKA_BROKERCONNECT: "kafka:9092"
+    depends_on:
+      - kafka
+
+  discoveryserver:
+    build:
+      context: ./../../DiscoveryServer
+    ports:
+      - "8761:8761"
+
+  gatewayservice:
+    build:
+      context: ./../../GatewayService
+    ports:
+      - "8080:8880"
+    environment:
+      - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://discoveryserver:8761/eureka
+    depends_on:
+      - discoveryserver
+
+  accountservice:
+    build:
+      context: ./../../AccountService
+    environment:
+      - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://discoveryserver:8761/eureka
+    depends_on:
+      - discoveryserver
+
+  cartservice:
+    build:
+      context: ./../../CartService
+    environment:
+      - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://discoveryserver:8761/eureka
+    depends_on:
+      - discoveryserver
+
+  catalogservice:
+    build:
+      context: ./../../CatalogService
+    environment:
+      - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://discoveryserver:8761/eureka
+    depends_on:
+      - discoveryserver
+
+  orderservice:
+    build:
+      context: ./../../OrderService
+    environment:
+      - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://discoveryserver:8761/eureka
+    depends_on:
+      - discoveryserver
 
 volumes:
   redis-data:

--- a/docker/local/nginx.conf
+++ b/docker/local/nginx.conf
@@ -18,33 +18,41 @@ http {
         listen 80;
         server_name localhost;
 
-        # /account/* → 로컬 8081
+        # Default: / -> gatewayservice
+        location / {
+            proxy_pass         http://gatewayservice:8880; # Corrected port and service name
+            proxy_set_header   Host $host;
+            proxy_set_header   X-Real-IP $remote_addr;
+            proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        # /account/* → accountservice
         location /account {
-            proxy_pass         http://host.docker.internal:8081;
+            proxy_pass         http://accountservice:8081; # Corrected port and service name
             proxy_set_header   Host $host;
             proxy_set_header   X-Real-IP $remote_addr;
             proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
-        # /cart/* → 로컬 8082
+        # /cart/* → cartservice
         location /cart {
-            proxy_pass         http://host.docker.internal:8082;
+            proxy_pass         http://cartservice:8082; # Corrected port and service name
             proxy_set_header   Host $host;
             proxy_set_header   X-Real-IP $remote_addr;
             proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
-        # /catalog/* → 로컬 8083
+        # /catalog/* → catalogservice
         location /catalog {
-            proxy_pass         http://host.docker.internal:8083;
+            proxy_pass         http://catalogservice:8083; # Corrected port and service name
             proxy_set_header   Host $host;
             proxy_set_header   X-Real-IP $remote_addr;
             proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
-        # /order/* → 로컬 8084
+        # /order/* → orderservice
         location /order {
-            proxy_pass         http://host.docker.internal:8084;
+            proxy_pass         http://orderservice:8084; # Corrected port and service name
             proxy_set_header   Host $host;
             proxy_set_header   X-Real-IP $remote_addr;
             proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
[Feat] CatalogService 카프카 보상 트랜잭션 정상 동작 및 DB 롤백 통합 테스트 추가

## 작업 배경 및 목적
Saga 패턴 환경에서 CatalogService 가 수신하는 Kafka 보상 이벤트(product_compensation 토픽)가 정상적으로 처리되는지 검증하기 위함입니다.
카프카 메시지 수신 후 실제 DB의 아이템 재고(Inventory Quantity)가 올바르게 롤백(복구)되는지 End-to-End 흐름을 확인하는 통합 테스트를 추가했습니다.


### 주요 변경 사항
**1. 통합 테스트 인프라 구성 ( ```build.gradle & @EmbeddedKafka```)**
테스트 환경 구축을 위해 spring-kafka-test 의존성을 추가했습니다.
외부 의존성 없이 독립적인 테스트를 수행할 수 있도록 @EmbeddedKafka를 활용해 인메모리 카프카 클러스터를 띄웠습니다.

**2. 프로듀서 및 컨슈머 직렬화/역직렬화 오류 해결 (RollbackIntegrationTest.java)**
카프카 메시지 페이로드로 사용되는 HashMap 타입 데이터를 직렬화할 때 발생하던 SerializationException을 해결했습니다.
```@SpringBootTest ```프로퍼티에 ```spring.kafka.producer.value-serializer=JsonSerializer```를 지정하여  KafkaTemplate이 JSON 직렬화를 수행하도록 구성했습니다.

**3. 커스텀 컨슈머 설정과 테스트 환경 브로커 간 포트(Port) 매핑 문제 해결.**  
어플리케이션의 KafkaConsumerConfig 가 하드코딩된 ${kafka.bootstrap-servers}를 참조하여 리스너가 동작하지 않는 문제를 확인했습니다.
테스트 환경의 프로퍼티에 kafka.bootstrap-servers=${spring.kafka.bootstrap-servers}를 매핑하여, 컨슈머가 올바르게 임베디드 카프카 브로커를 바라보게 수정했습니다.

**5. 메시지 유실에 따른 테스트 플래키니스(Flakiness) 개선**
카프카의 기본 auto.offset.reset=latest 특성으로 인해, 테스트 컨슈머(Listener)가 파티션 할당을 온전히 마치기 전에 프로듀서가 메시지를 쏴버리는 Race Condition이 발생하여 테스트가 간헐적으로 실패하는 현상을 발견했습니다.
@BeforeEach 단계에 ContainerTestUtils.waitForAssignment 코드를 추가해 카프카 컨슈머가 파티션을 모두 할당받을 때까지 안정적으로 대기한 후 보상 이벤트를 발행하도록 개선했습니다.

**6. DB 롤백 검증 로직 작성**
카프카 메시지로 { "EST-1": 10 } 데이터를 전송하기 전/후에 DB의  ItemQuantity를 조회하여, 재고가 실제로 10개 증가(복구)했는지 단언(assertEquals)하는 완벽한 검증 로직을 구현했습니다.