### PR TITLE
[Feature/compensation] Kafka 보상 이벤트 처리 병렬화 및 컨슈머 성능 최적화

### DIFF
--- a/AccountService/Dockerfile
+++ b/AccountService/Dockerfile
@@ -1,10 +1,4 @@
-FROM gradle:8.4-jdk21 AS build
-WORKDIR /workspace
-COPY . .
-RUN ./gradlew :AccountService:bootWar -x test --no-daemon
-
-FROM eclipse-temurin:21-jre
-WORKDIR /app
-COPY --from=build /workspace/AccountService/build/libs/*.war app.war
-EXPOSE 8081
-ENTRYPOINT ["java","-jar","app.war"]
+FROM eclipse-temurin:21-jdk
+ARG WAR_FILE=build/libs/*.war
+COPY ${WAR_FILE} app.war
+ENTRYPOINT ["java","-jar","/app.war"]

--- a/CartService/Dockerfile
+++ b/CartService/Dockerfile
@@ -1,10 +1,4 @@
-FROM gradle:8.4-jdk21 AS build
-WORKDIR /workspace
-COPY . .
-RUN ./gradlew :CartService:bootWar -x test --no-daemon
-
-FROM eclipse-temurin:21-jre
-WORKDIR /app
-COPY --from=build /workspace/CartService/build/libs/*.war app.war
-EXPOSE 8082
-ENTRYPOINT ["java","-jar","app.war"]
+FROM eclipse-temurin:17-jdk
+ARG WAR_FILE=build/libs/*.war
+COPY ${WAR_FILE} app.war
+ENTRYPOINT ["java","-jar","/app.war"]

--- a/CatalogService/Dockerfile
+++ b/CatalogService/Dockerfile
@@ -1,10 +1,4 @@
-FROM gradle:8.4-jdk21 AS build
-WORKDIR /workspace
-COPY . .
-RUN ./gradlew :CatalogService:bootWar -x test --no-daemon
-
-FROM eclipse-temurin:21-jre
-WORKDIR /app
-COPY --from=build /workspace/CatalogService/build/libs/*.war app.war
-EXPOSE 8083
-ENTRYPOINT ["java","-jar","app.war"]
+FROM eclipse-temurin:17-jdk
+ARG WAR_FILE=build/libs/*.war
+COPY ${WAR_FILE} app.war
+ENTRYPOINT ["java","-jar","/app.war"]

--- a/CatalogService/build.gradle
+++ b/CatalogService/build.gradle
@@ -8,6 +8,6 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
     implementation 'org.springframework.kafka:spring-kafka:3.3.7'
     implementation 'net.devh:grpc-server-spring-boot-starter:3.1.0.RELEASE'
-    testImplementation 'org.springframework.kafka:spring-kafka-test'
+    testImplementation 'org.springframework.kafka:spring-kafka-test:3.3.7'
 }
 

--- a/CatalogService/build.gradle
+++ b/CatalogService/build.gradle
@@ -4,8 +4,7 @@ archivesBaseName = 'jpetstore-catalog'
 
 dependencies {
     implementation project(':CommonLibrary')
-    implementation 'org.projectlombok:lombok:1.18.30'
-    implementation 'org.projectlombok:lombok:1.18.26'
+    compileOnly 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
     implementation 'org.springframework.kafka:spring-kafka:3.3.7'
     implementation 'net.devh:grpc-server-spring-boot-starter:3.1.0.RELEASE'

--- a/CatalogService/build.gradle
+++ b/CatalogService/build.gradle
@@ -9,5 +9,6 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
     implementation 'org.springframework.kafka:spring-kafka:3.3.7'
     implementation 'net.devh:grpc-server-spring-boot-starter:3.1.0.RELEASE'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 }
 

--- a/CatalogService/build.gradle
+++ b/CatalogService/build.gradle
@@ -5,6 +5,7 @@ archivesBaseName = 'jpetstore-catalog'
 dependencies {
     implementation project(':CommonLibrary')
     implementation 'org.projectlombok:lombok:1.18.30'
+    implementation 'org.projectlombok:lombok:1.18.26'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
     implementation 'org.springframework.kafka:spring-kafka:3.3.7'
     implementation 'net.devh:grpc-server-spring-boot-starter:3.1.0.RELEASE'

--- a/CatalogService/src/main/java/org/mybatis/jpetstore/catalog/controller/CatalogController.java
+++ b/CatalogService/src/main/java/org/mybatis/jpetstore/catalog/controller/CatalogController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.*;
 import java.util.HashMap;
 import java.util.List;
 
-
 @Controller
 @RequiredArgsConstructor
 public class CatalogController {

--- a/CatalogService/src/main/java/org/mybatis/jpetstore/catalog/kafka/KafkaConsumerConfig.java
+++ b/CatalogService/src/main/java/org/mybatis/jpetstore/catalog/kafka/KafkaConsumerConfig.java
@@ -22,6 +22,9 @@ public class KafkaConsumerConfig {
     @Value("${kafka.bootstrap-servers}")
     private String bootstrapServers;
 
+    @Value("${kafka.consumer.concurrency:1}")
+    private int concurrency;
+
     @Bean
     public ConsumerFactory<String, Object> consumerFactory() {
         Map<String, Object> config = new HashMap<>();
@@ -37,6 +40,7 @@ public class KafkaConsumerConfig {
     public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
         ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
+        factory.setConcurrency(concurrency);
         return factory;
     }
 }

--- a/CatalogService/src/test/java/org/mybatis/jpetstore/catalog/service/KafkaConcurrencyTest.java
+++ b/CatalogService/src/test/java/org/mybatis/jpetstore/catalog/service/KafkaConcurrencyTest.java
@@ -1,0 +1,95 @@
+package org.mybatis.jpetstore.catalog.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mybatis.jpetstore.catalog.CatalogServiceApplication;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.listener.MessageListenerContainer;
+import org.springframework.kafka.test.utils.ContainerTestUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+
+@SpringBootTest(classes = CatalogServiceApplication.class, properties = {
+    "eureka.client.enabled=false",
+    "spring.cloud.discovery.enabled=false",
+    "spring.cloud.compatibility-verifier.enabled=false",
+    "spring.sql.init.mode=always",
+    "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,org.mybatis.jpetstore.common.config.CommonAutoConfiguration",
+    "spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer",
+    "spring.kafka.consumer.properties.spring.json.trusted.packages=*",
+    "spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer",
+    "kafka.bootstrap-servers=${spring.kafka.bootstrap-servers}",
+    "kafka.consumer.concurrency=3", // 3개의 스레드 활성화 (메인 설정 활용)
+    "grpc.server.port=0"
+})
+@EmbeddedKafka(partitions = 3, topics = {"product_compensation"}, bootstrapServersProperty = "spring.kafka.bootstrap-servers")
+@ActiveProfiles("test")
+public class KafkaConcurrencyTest {
+
+    @Autowired
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @SpyBean
+    private CatalogService catalogService;
+
+    @Autowired
+    private KafkaListenerEndpointRegistry kafkaListenerEndpointRegistry;
+
+    @Autowired
+    private EmbeddedKafkaBroker embeddedKafkaBroker;
+
+    @Test
+    @DisplayName("성능 입증 테스트: Concurrency=3 일 때 30개의 메시지를 병렬로 처리하는지 확인")
+    void measurePerformanceWithMultipleConsumers() throws InterruptedException {
+        // 파티션 할당 대기
+        for (MessageListenerContainer container : kafkaListenerEndpointRegistry.getListenerContainers()) {
+            ContainerTestUtils.waitForAssignment(container, embeddedKafkaBroker.getPartitionsPerTopic());
+        }
+
+        int messageCount = 30;
+        CountDownLatch latch = new CountDownLatch(messageCount);
+        AtomicInteger processedCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            Thread.sleep(100); // 100ms 지연, consumer가 만약 하나라면 해당 100ms만큼 blocking되는 구조
+            processedCount.incrementAndGet();
+            System.out.println("[CONSUMER] Thread: " + Thread.currentThread().getName() + " | Total: " + processedCount.get());
+            latch.countDown();
+            return null;
+        }).when(catalogService).rollbackInventory(any());
+
+        long startTime = System.currentTimeMillis();
+
+        for (int i = 0; i < messageCount; i++) {
+            Map<String, Object> data = new HashMap<>();
+            data.put("EST-" + (i % 5), 1);
+            // 키를 다르게 주어 3개 파티션에 골고루 분산
+            kafkaTemplate.send("product_compensation", "key-" + i, data);
+        }
+
+        boolean completed = latch.await(20, TimeUnit.SECONDS);
+        long endTime = System.currentTimeMillis();
+        long totalTime = endTime - startTime;
+
+        System.out.println("==========================================");
+        System.out.println("Message Count: " + messageCount);
+        System.out.println("Total Processing Time: " + totalTime + " ms");
+        System.out.println("==========================================");
+
+        assert(totalTime < 2500) : "Parallel processing is NOT working. Expected < 2500ms, but got " + totalTime + "ms";
+    }
+}

--- a/CatalogService/src/test/java/org/mybatis/jpetstore/catalog/service/RollbackIntegrationTest.java
+++ b/CatalogService/src/test/java/org/mybatis/jpetstore/catalog/service/RollbackIntegrationTest.java
@@ -19,7 +19,7 @@ import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.kafka.listener.MessageListenerContainer;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.verify;
 @SpringBootTest(classes = CatalogServiceApplication.class, properties = {
     "eureka.client.enabled=false",
     "spring.cloud.discovery.enabled=false",
+    "spring.cloud.compatibility-verifier.enabled=false",
     "spring.sql.init.mode=always",
     "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,org.mybatis.jpetstore.common.config.CommonAutoConfiguration",
     "spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer",
@@ -51,7 +52,7 @@ public class RollbackIntegrationTest {
     @Autowired
     private KafkaTemplate<String, Object> kafkaTemplate;
 
-    @MockitoSpyBean
+    @SpyBean
     private CatalogService catalogService;
 
     @Autowired

--- a/CatalogService/src/test/java/org/mybatis/jpetstore/catalog/service/RollbackIntegrationTest.java
+++ b/CatalogService/src/test/java/org/mybatis/jpetstore/catalog/service/RollbackIntegrationTest.java
@@ -1,0 +1,108 @@
+package org.mybatis.jpetstore.catalog.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mybatis.jpetstore.catalog.CatalogServiceApplication;
+import org.mybatis.jpetstore.catalog.controller.CatalogController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.ContainerTestUtils;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.listener.MessageListenerContainer;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Saga 패턴의 보상 트랜잭션 수신 측(Catalog Service) 통합 테스트입니다.
+ */
+@SpringBootTest(classes = CatalogServiceApplication.class, properties = {
+    "eureka.client.enabled=false",
+    "spring.cloud.discovery.enabled=false",
+    "spring.sql.init.mode=always",
+    "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,org.mybatis.jpetstore.common.config.CommonAutoConfiguration",
+    "spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer",
+    "spring.kafka.consumer.properties.spring.json.trusted.packages=*",
+    "spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer",
+    "kafka.bootstrap-servers=${spring.kafka.bootstrap-servers}",
+    "grpc.server.port=0"
+})
+@EmbeddedKafka(partitions = 1, topics = {"product_compensation"}, bootstrapServersProperty = "spring.kafka.bootstrap-servers")
+@ActiveProfiles("test")
+public class RollbackIntegrationTest {
+
+    @Autowired
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @MockitoSpyBean
+    private CatalogService catalogService;
+
+    @Autowired
+    private CatalogController catalogController;
+
+    @Autowired
+    private KafkaListenerEndpointRegistry kafkaListenerEndpointRegistry;
+
+    @Autowired
+    private EmbeddedKafkaBroker embeddedKafkaBroker;
+
+    @BeforeEach
+    public void setUp() {
+        for (MessageListenerContainer messageListenerContainer : kafkaListenerEndpointRegistry.getListenerContainers()) {
+            ContainerTestUtils.waitForAssignment(messageListenerContainer, embeddedKafkaBroker.getPartitionsPerTopic());
+        }
+    }
+
+    @Test
+    @DisplayName("보상 트랜잭션 통합 테스트: Catalog 서비스는 Kafka 보상 이벤트를 받으면 실제 DB 재고를 복구해야 한다")
+    void verifyCatalogRollbackByKafkaEvent() {
+        // Given: 보상 이벤트 데이터 (아이템 EST-1, 수량 10개 복구)
+        Map<String, Object> data = new HashMap<>();
+        data.put("EST-1", 10);
+
+        // 테스트 시작 전 EST-1 의 현재 재고 확인 (데이터로드 SQL 에 의해 10000개로 초기화됨)
+        Integer initialQuantity = catalogService.getItemQuantity("EST-1");
+        assertNotNull(initialQuantity);
+        System.out.println("=== [TEST] Initial DB Quantity for EST-1: " + initialQuantity + " ===");
+
+        // When: 실제 Kafka 토픽으로 메시지 전송
+        System.out.println("=== [TEST] SENDING COMPENSATION EVENT TO EMBEDDED KAFKA ===");
+        kafkaTemplate.send("product_compensation", data);
+        kafkaTemplate.flush();
+
+        // Then: CatalogController의 @KafkaListener가 동작하여 catalogService.rollbackInventory를 호출하는지 대기
+        verify(catalogService, timeout(15000).times(1)).rollbackInventory(any());
+        
+        // Kafka 메시지 처리로 인해 트랜잭션이 커밋되는 시간을 약간 대기 (필요시)
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        // DB 재고가 실제로 복구되었는지 확인
+        Integer updatedQuantity = catalogService.getItemQuantity("EST-1");
+        System.out.println("=== [TEST] Updated DB Quantity for EST-1: " + updatedQuantity + " ===");
+        
+        assertEquals(initialQuantity + 10, updatedQuantity);
+        
+        System.out.println("=== [TEST] VERIFIED: Catalog Service DB Rollback Triggered and Executed by REAL Kafka Event! ===");
+    }
+}

--- a/CatalogService/src/test/java/org/mybatis/jpetstore/controller/CatalogControllerTest.java
+++ b/CatalogService/src/test/java/org/mybatis/jpetstore/controller/CatalogControllerTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.mybatis.jpetstore.catalog.controller.CatalogController;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -23,7 +23,7 @@ class CatalogControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
-    @MockitoBean
+    @MockBean
     private CatalogService catalogService;
 
     // 메인 페이지 요청 시 정상적으로 뷰를 반환한다

--- a/DiscoveryServer/Dockerfile
+++ b/DiscoveryServer/Dockerfile
@@ -1,10 +1,4 @@
-FROM gradle:8.4-jdk21 AS build
-WORKDIR /workspace
-COPY . .
-RUN ./gradlew :DiscoveryServer:bootJar -x test --no-daemon
-
-FROM eclipse-temurin:21-jre
-WORKDIR /app
-COPY --from=build /workspace/DiscoveryServer/build/libs/*.jar app.jar
-EXPOSE 8761
-ENTRYPOINT ["java","-jar","app.jar"]
+FROM eclipse-temurin:17-jdk
+ARG WAR_FILE=build/libs/*.war
+COPY ${WAR_FILE} app.war
+ENTRYPOINT ["java","-jar","/app.war"]

--- a/GatewayService/Dockerfile
+++ b/GatewayService/Dockerfile
@@ -1,10 +1,4 @@
-FROM gradle:8.4-jdk21 AS build
-WORKDIR /workspace
-COPY . .
-RUN ./gradlew :GatewayService:bootJar -x test --no-daemon
-
-FROM eclipse-temurin:21-jre
-WORKDIR /app
-COPY --from=build /workspace/GatewayService/build/libs/*.jar app.jar
-EXPOSE 8880
-ENTRYPOINT ["java","-jar","app.jar"]
+FROM eclipse-temurin:17-jdk
+ARG WAR_FILE=build/libs/*.war
+COPY ${WAR_FILE} app.war
+ENTRYPOINT ["java","-jar","/app.war"]

--- a/OrderService/Dockerfile
+++ b/OrderService/Dockerfile
@@ -1,10 +1,4 @@
-FROM gradle:8.4-jdk21 AS build
-WORKDIR /workspace
-COPY . .
-RUN ./gradlew :OrderService:bootWar -x test --no-daemon
-
-FROM eclipse-temurin:21-jre
-WORKDIR /app
-COPY --from=build /workspace/OrderService/build/libs/*.war app.war
-EXPOSE 8084
-ENTRYPOINT ["java","-jar","app.war"]
+FROM eclipse-temurin:17-jdk
+ARG WAR_FILE=build/libs/*.war
+COPY ${WAR_FILE} app.war
+ENTRYPOINT ["java","-jar","/app.war"]

--- a/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
+++ b/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
@@ -31,6 +31,7 @@ import org.mybatis.jpetstore.common.grpc.CatalogGrpcClient;
 import org.mybatis.jpetstore.order.repository.LineItemRepository;
 import org.mybatis.jpetstore.order.repository.OrderRepository;
 import org.mybatis.jpetstore.order.repository.SequenceRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -64,6 +65,15 @@ public class OrderService {
   // 첫 주문 등의 이유로 지난 주문에 대한 내역이 없는 상태
   private static final String UNPROCESSED = "unprocessed";
   private static final String COMPENSATION_TOPIC = "product_compensation";
+
+  @Value("${order.chaos.force-persist-failure:false}")
+  private boolean forcePersistFailure;
+
+  @Value("${order.chaos.skip-compensation-on-persist-failure:false}")
+  private boolean skipCompensationOnPersistFailure;
+
+  @Value("${order.chaos.check-inventory-inconsistency-on-failure:true}")
+  private boolean checkInventoryInconsistencyOnFailure;
 
 
   /**
@@ -264,14 +274,43 @@ public class OrderService {
   private void persistOrderOrCompensate(Order order, Map<String, Object> incrementPerItem)
       throws OrderFailException {
     try {
+      if (forcePersistFailure) {
+        throw new IllegalStateException("Chaos mode: forced order persistence failure");
+      }
       orderRepository.insert(order);
       orderRepository.updateStatus(new OrderRetryStatus(order.getOrderId(), SUCCESS));
     } catch (Exception e) {
-      log.error("Order persistence failed. Publishing compensation transaction. orderId={}",
+      log.error("Order persistence failed. orderId={}",
           order.getOrderId(), e);
-      kafkaTemplate.send(COMPENSATION_TOPIC, incrementPerItem);
+
+      if (skipCompensationOnPersistFailure) {
+        log.error("Chaos mode: skipping compensation transaction on failure. orderId={}",
+            order.getOrderId());
+      } else {
+        kafkaTemplate.send(COMPENSATION_TOPIC, incrementPerItem);
+      }
+
+      logPotentialInventoryInconsistency(order.getOrderId());
       orderRepository.updateStatus(new OrderRetryStatus(order.getOrderId(), FAIL));
-      throw new OrderFailException("주문 저장 실패로 보상 트랜잭션이 발행되었습니다.");
+      throw new OrderFailException("주문 저장에 실패했습니다.");
+    }
+  }
+
+  private void logPotentialInventoryInconsistency(int orderId) {
+    if (!checkInventoryInconsistencyOnFailure) {
+      return;
+    }
+
+    try {
+      boolean inventoryCommitSucceeded = catalogGrpcClient.isInventoryUpdateCommitSuccess(orderId);
+      if (inventoryCommitSucceeded) {
+        log.error("INVENTORY_INCONSISTENCY_DETECTED - inventory was already committed but order failed. orderId={}",
+            orderId);
+      } else {
+        log.info("Inventory update was not committed, no inconsistency detected. orderId={}", orderId);
+      }
+    } catch (Exception exception) {
+      log.warn("Failed to verify potential inventory inconsistency. orderId={}", orderId, exception);
     }
   }
 

--- a/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
+++ b/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
@@ -168,43 +168,43 @@ public class OrderService {
    *
    * @param order 생성할 주문
    */
+
+  // TODO : 그리고 멱등성에 대한 UUID 키는 프론트에서 주는것. ORDER_ID가 아니다.프론트에서 사용자가 동일한 주문을 여러번 요청하는치 판단하고, header로 UUID 키를 주는게 맞다.
+  // TODO : 로직이 너무 복잡하다. 리팩토링 필요
   @Transactional
   public void insertOrder(Order order, HttpSession session) throws OrderFailException, RetryUnknownException {
 
-      Optional<OrderRetryStatus> orderRetryStatus = orderRepository.findStatus(order.getOrderId());
+    Optional<OrderRetryStatus> orderRetryStatus = orderRepository.findStatus(order.getOrderId());
 
-      if (!orderRetryStatus.isPresent()){
-          orderRepository.insertStatus(new OrderRetryStatus(order.getOrderId(), UNPROCESSED));
-          orderRetryStatus = orderRepository.findStatus(order.getOrderId());
-      }
+    if (!orderRetryStatus.isPresent()) {
+      orderRepository.insertStatus(new OrderRetryStatus(order.getOrderId(), UNPROCESSED));
+      orderRetryStatus = orderRepository.findStatus(order.getOrderId());
+    }
 
-      if(orderRetryStatus.get().getStatus().equals(SUCCESS)){
-        return;
-      }
+    if (orderRetryStatus.get().getStatus().equals(SUCCESS)) {
+      return;
+    }
 
-      // Unknown 재요청 실패한 경우 -> 재요청 필요
-      if (orderRetryStatus.get().getStatus().equals(UNKNOWN)){
-        updateCommitSuccessCheck(order);
-      }
+    // Unknown 재요청 실패한 경우 -> 재요청 필요
+    if (orderRetryStatus.get().getStatus().equals(UNKNOWN)) {
+      updateCommitSuccessCheck(order);
+    }
 
     Map<String, Object> incrementPerItem = getIncrementAndItemsParam(order);
-    boolean resp = catalogGrpcClient.updateInventoryQuantity(incrementPerItem,order.getOrderId());
+    boolean resp = catalogGrpcClient.updateInventoryQuantity(incrementPerItem, order.getOrderId());
 
     // 즉시 재요청 : 5xx error, Time-out 발생한 경우 (비정상 실패)
     if (!resp) {
       updateCommitSuccessCheck(order);
     }
 
-    try{
-      orderRepository.insert(order);
-    }catch (Exception e){
-      kafkaTemplate.send("product_compensation",incrementPerItem);
+    try {
+      orderRepository.insert(
+          order); // TODO : commit이 됐으니까 보상을 하지 않겠다는건 말이 안됨. 어쨌든 error가 발생한 상황이고 다른 지점에 문제가 발생했을 수 있기 때문에 보상을 하지 않더라도 주문을 로직을 완료처리해서는 안됨
+    } catch (Exception e) {
+      kafkaTemplate.send("product_compensation", incrementPerItem);
+      orderRepository.updateStatus(new OrderRetryStatus(order.getOrderId(), SUCCESS));
     }
-
-
-
-
-    orderRepository.updateStatus(new OrderRetryStatus(order.getOrderId(), SUCCESS));
   }
 
   private static Map<String, Object> getIncrementAndItemsParam(Order order) {

--- a/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
+++ b/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
@@ -169,7 +169,7 @@ public class OrderService {
    * @param order 생성할 주문
    */
 
-  // TODO : 그리고 멱등성에 대한 UUID 키는 프론트에서 주는것. ORDER_ID가 아니다.프론트에서 사용자가 동일한 주문을 여러번 요청하는치 판단하고, header로 UUID 키를 주는게 맞다.
+  // TODO : 그리고 멱등성에 처리 방식에 대해서도 재고민해 볼 필요가 있을 것 같다.
   // TODO : 로직이 너무 복잡하다. 리팩토링 필요
   @Transactional
   public void insertOrder(Order order, HttpSession session) throws OrderFailException, RetryUnknownException {

--- a/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
+++ b/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
@@ -174,7 +174,7 @@ public class OrderService {
   @Transactional
   public void insertOrder(Order order, HttpSession session) throws OrderFailException, RetryUnknownException {
 
-    Optional<OrderRetryStatus> orderRetryStatus = orderRepository.findStatus(order.getOrderId());
+    Optional<OrderRetryStatus> orderRetryStatus = orderRepository.findStatus(order.getOrderId()); // 재요청 상태 조회를 orderID로 하면 안된다고 생각한다. -> 프론트에서 주는 UUID 키로 해야함
 
     if (!orderRetryStatus.isPresent()) {
       orderRepository.insertStatus(new OrderRetryStatus(order.getOrderId(), UNPROCESSED));
@@ -188,9 +188,9 @@ public class OrderService {
     // Unknown 재요청 실패한 경우 -> 재요청 필요
     if (orderRetryStatus.get().getStatus().equals(UNKNOWN)) {
       updateCommitSuccessCheck(order);
-    }
+    } // TODO : 분기가 너무 많다.
 
-    Map<String, Object> incrementPerItem = getIncrementAndItemsParam(order);
+    Map<String, Object> incrementPerItem = getIncrementAndItemsParam(order); // TODO : item에 대한 재고와 수량만 넘기면 되는것이 맞는지 재고민
     boolean resp = catalogGrpcClient.updateInventoryQuantity(incrementPerItem, order.getOrderId());
 
     // 즉시 재요청 : 5xx error, Time-out 발생한 경우 (비정상 실패)

--- a/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
+++ b/OrderService/src/main/java/org/mybatis/jpetstore/order/service/OrderService.java
@@ -63,6 +63,7 @@ public class OrderService {
   private static final String FAIL = "fail";
   // 첫 주문 등의 이유로 지난 주문에 대한 내역이 없는 상태
   private static final String UNPROCESSED = "unprocessed";
+  private static final String COMPENSATION_TOPIC = "product_compensation";
 
 
   /**
@@ -170,41 +171,18 @@ public class OrderService {
    */
 
   // TODO : 그리고 멱등성에 처리 방식에 대해서도 재고민해 볼 필요가 있을 것 같다.
-  // TODO : 로직이 너무 복잡하다. 리팩토링 필요
   @Transactional
   public void insertOrder(Order order, HttpSession session) throws OrderFailException, RetryUnknownException {
-
-    Optional<OrderRetryStatus> orderRetryStatus = orderRepository.findStatus(order.getOrderId()); // 재요청 상태 조회를 orderID로 하면 안된다고 생각한다. -> 프론트에서 주는 UUID 키로 해야함
-
-    if (!orderRetryStatus.isPresent()) {
-      orderRepository.insertStatus(new OrderRetryStatus(order.getOrderId(), UNPROCESSED));
-      orderRetryStatus = orderRepository.findStatus(order.getOrderId());
-    }
-
-    if (orderRetryStatus.get().getStatus().equals(SUCCESS)) {
+    OrderRetryStatus retryStatus = getOrCreateRetryStatus(order.getOrderId());
+    if (isOrderAlreadySucceeded(retryStatus)) {
       return;
     }
 
-    // Unknown 재요청 실패한 경우 -> 재요청 필요
-    if (orderRetryStatus.get().getStatus().equals(UNKNOWN)) {
-      updateCommitSuccessCheck(order);
-    } // TODO : 분기가 너무 많다.
+    ensureUnknownStateIsRecoverable(retryStatus, order);
 
-    Map<String, Object> incrementPerItem = getIncrementAndItemsParam(order); // TODO : item에 대한 재고와 수량만 넘기면 되는것이 맞는지 재고민
-    boolean resp = catalogGrpcClient.updateInventoryQuantity(incrementPerItem, order.getOrderId());
-
-    // 즉시 재요청 : 5xx error, Time-out 발생한 경우 (비정상 실패)
-    if (!resp) {
-      updateCommitSuccessCheck(order);
-    }
-
-    try {
-      orderRepository.insert(
-          order); // TODO : commit이 됐으니까 보상을 하지 않겠다는건 말이 안됨. 어쨌든 error가 발생한 상황이고 다른 지점에 문제가 발생했을 수 있기 때문에 보상을 하지 않더라도 주문을 로직을 완료처리해서는 안됨
-    } catch (Exception e) {
-      kafkaTemplate.send("product_compensation", incrementPerItem);
-      orderRepository.updateStatus(new OrderRetryStatus(order.getOrderId(), SUCCESS));
-    }
+    Map<String, Object> incrementPerItem = getIncrementAndItemsParam(order);
+    updateInventoryOrThrow(order, incrementPerItem);
+    persistOrderOrCompensate(order, incrementPerItem);
   }
 
   private static Map<String, Object> getIncrementAndItemsParam(Order order) {
@@ -226,12 +204,15 @@ public class OrderService {
       // 즉시 재요청 - 수량 변경 commit 성공 여부 확인
       boolean isCommitSuccess = catalogGrpcClient.isInventoryUpdateCommitSuccess(sessionOrder.getOrderId());
 
-      if (!isCommitSuccess) {
-        // fail : Known_case2 : commit 실패한 경우 -> 실패 처리
-        log.info("Known_case2_commitFail");
-        orderRepository.updateStatus(new OrderRetryStatus(sessionOrder.getOrderId(), FAIL));
-        throw new OrderFailException("주문 실패");
+      // commit 성공 여부와 무관하게 현재 주문은 실패 처리하고 보상 트랜잭션 발행
+      if (isCommitSuccess) {
+        log.info("Known_case1_commitSuccess_compensationNeeded");
+        publishCompensation(sessionOrder);
       }
+
+      log.info("Known_case2_commitFail");
+      orderRepository.updateStatus(new OrderRetryStatus(sessionOrder.getOrderId(), FAIL));
+      throw new OrderFailException("주문 실패");
 
     } catch(HttpServerErrorException serverError){
         // Unknown : 즉시 재요청에 server Error 발생, 트랜잭션 커밋 성공 여부를 알 수 없는 경우
@@ -245,7 +226,53 @@ public class OrderService {
         orderRepository.updateStatus(new OrderRetryStatus(sessionOrder.getOrderId(), UNKNOWN));
         throw new RetryUnknownException("리소스 접근 예외 발생 - time out");
       }
-    log.info("문제 없음");
+  }
+
+  private OrderRetryStatus getOrCreateRetryStatus(int orderId) {
+    return orderRepository.findStatus(orderId)
+        .orElseGet(() -> {
+          orderRepository.insertStatus(new OrderRetryStatus(orderId, UNPROCESSED));
+          return new OrderRetryStatus(orderId, UNPROCESSED);
+        });
+  }
+
+  private boolean isOrderAlreadySucceeded(OrderRetryStatus retryStatus) {
+    return SUCCESS.equals(retryStatus.getStatus());
+  }
+
+  private void ensureUnknownStateIsRecoverable(OrderRetryStatus retryStatus, Order order)
+      throws OrderFailException, RetryUnknownException {
+    if (UNKNOWN.equals(retryStatus.getStatus())) {
+      updateCommitSuccessCheck(order);
+    }
+  }
+
+  private void updateInventoryOrThrow(Order order, Map<String, Object> incrementPerItem)
+      throws OrderFailException, RetryUnknownException {
+    boolean inventoryUpdated = catalogGrpcClient.updateInventoryQuantity(incrementPerItem, order.getOrderId());
+    if (!inventoryUpdated) {
+      updateCommitSuccessCheck(order);
+    }
+  }
+
+
+  private void publishCompensation(Order order) {
+    Map<String, Object> incrementPerItem = getIncrementAndItemsParam(order);
+    kafkaTemplate.send(COMPENSATION_TOPIC, incrementPerItem);
+  }
+
+  private void persistOrderOrCompensate(Order order, Map<String, Object> incrementPerItem)
+      throws OrderFailException {
+    try {
+      orderRepository.insert(order);
+      orderRepository.updateStatus(new OrderRetryStatus(order.getOrderId(), SUCCESS));
+    } catch (Exception e) {
+      log.error("Order persistence failed. Publishing compensation transaction. orderId={}",
+          order.getOrderId(), e);
+      kafkaTemplate.send(COMPENSATION_TOPIC, incrementPerItem);
+      orderRepository.updateStatus(new OrderRetryStatus(order.getOrderId(), FAIL));
+      throw new OrderFailException("주문 저장 실패로 보상 트랜잭션이 발행되었습니다.");
+    }
   }
 
   /**

--- a/OrderService/src/main/resources/application.yml
+++ b/OrderService/src/main/resources/application.yml
@@ -51,3 +51,8 @@ eureka:
   instance:
     prefer-ip-address: true
     instance-id: ${spring.application.name}:${server.port}
+order:
+  chaos:
+    force-persist-failure: ${ORDER_CHAOS_FORCE_PERSIST_FAILURE:false}
+    skip-compensation-on-persist-failure: ${ORDER_CHAOS_SKIP_COMPENSATION_ON_PERSIST_FAILURE:false}
+    check-inventory-inconsistency-on-failure: ${ORDER_CHAOS_CHECK_INVENTORY_INCONSISTENCY_ON_FAILURE:true}

--- a/OrderService/src/test/java/org/mybatis/jpetstore/order/service/CompensationIntegrationTest.java
+++ b/OrderService/src/test/java/org/mybatis/jpetstore/order/service/CompensationIntegrationTest.java
@@ -1,0 +1,96 @@
+package org.mybatis.jpetstore.order.service;
+
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mybatis.jpetstore.common.domain.LineItem;
+import org.mybatis.jpetstore.common.domain.Order;
+import org.mybatis.jpetstore.common.grpc.CatalogGrpcClient;
+import org.mybatis.jpetstore.order.domain.OrderRetryStatus;
+import org.mybatis.jpetstore.order.exception.OrderFailException;
+import org.mybatis.jpetstore.order.repository.LineItemRepository;
+import org.mybatis.jpetstore.order.repository.OrderRepository;
+import org.mybatis.jpetstore.order.repository.SequenceRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(properties = {
+    "spring.session.store-type=none",
+    "eureka.client.enabled=false",
+    "spring.cloud.discovery.enabled=false",
+    "spring.sql.init.mode=never",
+    "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,org.mybatis.jpetstore.common.config.CommonAutoConfiguration",
+    "spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer"
+})
+@EmbeddedKafka(partitions = 1, topics = {"product_compensation"}, bootstrapServersProperty = "spring.kafka.bootstrap-servers")
+@ActiveProfiles("test")
+public class CompensationIntegrationTest {
+
+    @Autowired
+    private OrderService orderService;
+
+    @MockitoBean
+    private OrderRepository orderRepository;
+    @MockitoBean
+    private SequenceRepository sequenceRepository;
+    @MockitoBean
+    private LineItemRepository lineItemRepository;
+    @MockitoBean
+    private CatalogGrpcClient catalogGrpcClient;
+    @MockitoBean
+    private HttpSession session;
+
+    // KafkaTemplate을 Spy로 등록하여 실제 전송 호출을 캡처
+    @MockitoSpyBean
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Test
+    @DisplayName("보상 트랜잭션 통합 테스트: 주문 저장 실패 시 KafkaTemplate.send 가 실제로 호출되어야 한다")
+    void verifyKafkaTemplateCallOnFailure() throws Exception {
+        // Given
+        Order order = new Order();
+        order.setOrderId(7777);
+        List<LineItem> lineItems = new ArrayList<>();
+        LineItem item = new LineItem();
+        item.setItemId("EST-1");
+        item.setQuantity(3);
+        lineItems.add(item);
+        order.setLineItems(lineItems);
+
+        when(catalogGrpcClient.updateInventoryQuantity(any(), anyInt())).thenReturn(true);
+        when(orderRepository.findStatus(anyInt())).thenReturn(Optional.of(new OrderRetryStatus(7777, "unprocessed")));
+        
+        doThrow(new RuntimeException("DB_SAVE_ERROR")).when(orderRepository).insert(any(Order.class));
+
+        // When
+        try {
+            orderService.insertOrder(order, session);
+        } catch (OrderFailException e) {
+            // expected
+        }
+
+        // Then: KafkaTemplate.send 가 올바른 토픽과 데이터로 호출되었는지 확인
+        // Map 형태의 데이터가 전송되므로 ArgumentMatcher 사용
+        verify(kafkaTemplate, timeout(5000).times(1)).send(eq("product_compensation"), argThat(map -> {
+            Map<String, Object> param = (Map<String, Object>) map;
+            return param.containsKey("EST-1") && param.get("EST-1").toString().equals("3");
+        }));
+        
+        System.out.println("=== VERIFIED: KafkaTemplate.send was called with correct compensation data! ===");
+    }
+}

--- a/OrderService/src/test/java/org/mybatis/jpetstore/order/service/OrderServiceTest.java
+++ b/OrderService/src/test/java/org/mybatis/jpetstore/order/service/OrderServiceTest.java
@@ -1,0 +1,69 @@
+package org.mybatis.jpetstore.order.service;
+
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mybatis.jpetstore.common.domain.Order;
+import org.mybatis.jpetstore.common.grpc.CatalogGrpcClient;
+import org.mybatis.jpetstore.order.domain.OrderRetryStatus;
+import org.mybatis.jpetstore.order.exception.OrderFailException;
+import org.mybatis.jpetstore.order.exception.RetryUnknownException;
+import org.mybatis.jpetstore.order.repository.OrderRepository;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Mock
+    private CatalogGrpcClient catalogGrpcClient;
+
+    @Mock
+    private HttpSession session;
+
+    @InjectMocks
+    private OrderService orderService;
+
+    @Test
+    @DisplayName("주문 저장 실패 시 Kafka 보상 메시지가 발행되는지 확인")
+    void shouldSendKafkaMessageWhenOrderInsertFails() throws OrderFailException, RetryUnknownException {
+        // 1. 테스트 데이터 준비
+        Order order = new Order();
+        order.setOrderId(1001);
+        order.setLineItems(new java.util.ArrayList<>());
+
+        // 2. Mock 설정
+        when(orderRepository.findStatus(anyInt()))
+            .thenReturn(Optional.empty())
+            .thenReturn(Optional.of(new OrderRetryStatus(1001, "unprocessed")));
+        
+        when(catalogGrpcClient.updateInventoryQuantity(any(), anyInt())).thenReturn(true);
+
+        // 핵심: orderRepository.insert 호출 시 강제로 예외 발생
+        doThrow(new RuntimeException("DB Insert Error")).when(orderRepository).insert(any(Order.class));
+
+        // 3. 테스트 실행
+        orderService.insertOrder(order, session);
+
+        // 4. 검증: kafkaTemplate.send가 "product_compensation" 토픽으로 호출되었는지 확인
+        verify(kafkaTemplate, times(1)).send(eq("product_compensation"), any());
+        
+        // 추가 검증: 상태가 success로 업데이트 되었는지 확인
+        verify(orderRepository, times(1)).updateStatus(argThat(status -> status.getStatus().equals("success")));
+    }
+}

--- a/OrderService/src/test/java/org/mybatis/jpetstore/order/service/OrderServiceTest.java
+++ b/OrderService/src/test/java/org/mybatis/jpetstore/order/service/OrderServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -40,8 +41,8 @@ class OrderServiceTest {
     private OrderService orderService;
 
     @Test
-    @DisplayName("주문 저장 실패 시 Kafka 보상 메시지가 발행되는지 확인")
-    void shouldSendKafkaMessageWhenOrderInsertFails() throws OrderFailException, RetryUnknownException {
+    @DisplayName("주문 저장 실패 시 Kafka 보상 메시지를 발행하고 실패 처리한다")
+    void shouldCompensateAndFailWhenOrderInsertFails() throws RetryUnknownException {
         // 1. 테스트 데이터 준비
         Order order = new Order();
         order.setOrderId(1001);
@@ -49,8 +50,7 @@ class OrderServiceTest {
 
         // 2. Mock 설정
         when(orderRepository.findStatus(anyInt()))
-            .thenReturn(Optional.empty())
-            .thenReturn(Optional.of(new OrderRetryStatus(1001, "unprocessed")));
+            .thenReturn(Optional.empty());
         
         when(catalogGrpcClient.updateInventoryQuantity(any(), anyInt())).thenReturn(true);
 
@@ -58,12 +58,30 @@ class OrderServiceTest {
         doThrow(new RuntimeException("DB Insert Error")).when(orderRepository).insert(any(Order.class));
 
         // 3. 테스트 실행
-        orderService.insertOrder(order, session);
+        assertThrows(OrderFailException.class, () -> orderService.insertOrder(order, session));
 
         // 4. 검증: kafkaTemplate.send가 "product_compensation" 토픽으로 호출되었는지 확인
         verify(kafkaTemplate, times(1)).send(eq("product_compensation"), any());
         
-        // 추가 검증: 상태가 success로 업데이트 되었는지 확인
-        verify(orderRepository, times(1)).updateStatus(argThat(status -> status.getStatus().equals("success")));
+        // 추가 검증: 상태가 fail로 업데이트 되었는지 확인
+        verify(orderRepository, times(1)).updateStatus(argThat(status -> status.getStatus().equals("fail")));
     }
+
+    @Test
+    @DisplayName("inventory commit 성공 확인 시에도 보상 트랜잭션을 발행하고 실패 처리한다")
+    void shouldCompensateAndFailWhenCommitSuccessIsConfirmed() throws RetryUnknownException {
+        Order order = new Order();
+        order.setOrderId(2002);
+        order.setLineItems(new java.util.ArrayList<>());
+
+        when(orderRepository.findStatus(anyInt())).thenReturn(Optional.of(new OrderRetryStatus(2002, "unknown")));
+        when(catalogGrpcClient.isInventoryUpdateCommitSuccess(2002)).thenReturn(true);
+
+        assertThrows(OrderFailException.class, () -> orderService.insertOrder(order, session));
+
+        verify(kafkaTemplate, times(1)).send(eq("product_compensation"), any());
+        verify(orderRepository, times(1)).updateStatus(argThat(status -> status.getStatus().equals("fail")));
+        verify(orderRepository, never()).insert(any(Order.class));
+    }
+
 }

--- a/OrderService/src/test/java/org/mybatis/jpetstore/order/service/OrderServiceTest.java
+++ b/OrderService/src/test/java/org/mybatis/jpetstore/order/service/OrderServiceTest.java
@@ -14,11 +14,13 @@ import org.mybatis.jpetstore.order.exception.OrderFailException;
 import org.mybatis.jpetstore.order.exception.RetryUnknownException;
 import org.mybatis.jpetstore.order.repository.OrderRepository;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -43,27 +45,17 @@ class OrderServiceTest {
     @Test
     @DisplayName("주문 저장 실패 시 Kafka 보상 메시지를 발행하고 실패 처리한다")
     void shouldCompensateAndFailWhenOrderInsertFails() throws RetryUnknownException {
-        // 1. 테스트 데이터 준비
         Order order = new Order();
         order.setOrderId(1001);
         order.setLineItems(new java.util.ArrayList<>());
 
-        // 2. Mock 설정
-        when(orderRepository.findStatus(anyInt()))
-            .thenReturn(Optional.empty());
-        
+        when(orderRepository.findStatus(anyInt())).thenReturn(Optional.empty());
         when(catalogGrpcClient.updateInventoryQuantity(any(), anyInt())).thenReturn(true);
-
-        // 핵심: orderRepository.insert 호출 시 강제로 예외 발생
         doThrow(new RuntimeException("DB Insert Error")).when(orderRepository).insert(any(Order.class));
 
-        // 3. 테스트 실행
         assertThrows(OrderFailException.class, () -> orderService.insertOrder(order, session));
 
-        // 4. 검증: kafkaTemplate.send가 "product_compensation" 토픽으로 호출되었는지 확인
         verify(kafkaTemplate, times(1)).send(eq("product_compensation"), any());
-        
-        // 추가 검증: 상태가 fail로 업데이트 되었는지 확인
         verify(orderRepository, times(1)).updateStatus(argThat(status -> status.getStatus().equals("fail")));
     }
 
@@ -84,4 +76,43 @@ class OrderServiceTest {
         verify(orderRepository, never()).insert(any(Order.class));
     }
 
+    @Test
+    @DisplayName("Chaos 모드에서 주문 저장 실패를 강제로 발생시키고 보상 트랜잭션을 발행한다")
+    void shouldForcePersistFailureAndPublishCompensationInChaosMode() {
+        Order order = new Order();
+        order.setOrderId(3003);
+        order.setLineItems(new java.util.ArrayList<>());
+
+        ReflectionTestUtils.setField(orderService, "forcePersistFailure", true);
+
+        when(orderRepository.findStatus(anyInt())).thenReturn(Optional.empty());
+        when(catalogGrpcClient.updateInventoryQuantity(any(), anyInt())).thenReturn(true);
+
+        assertThrows(OrderFailException.class, () -> orderService.insertOrder(order, session));
+
+        verify(kafkaTemplate, times(1)).send(eq("product_compensation"), any());
+        verify(orderRepository, never()).insert(any(Order.class));
+        verify(orderRepository, times(1)).updateStatus(argThat(status -> status.getStatus().equals("fail")));
+    }
+
+    @Test
+    @DisplayName("Chaos 모드에서 보상 트랜잭션을 생략하면 Kafka 보상 메시지를 발행하지 않는다")
+    void shouldSkipCompensationWhenChaosFlagIsEnabled() {
+        Order order = new Order();
+        order.setOrderId(4004);
+        order.setLineItems(new java.util.ArrayList<>());
+
+        ReflectionTestUtils.setField(orderService, "forcePersistFailure", true);
+        ReflectionTestUtils.setField(orderService, "skipCompensationOnPersistFailure", true);
+
+        when(orderRepository.findStatus(anyInt())).thenReturn(Optional.empty());
+        when(catalogGrpcClient.updateInventoryQuantity(any(), anyInt())).thenReturn(true);
+        when(catalogGrpcClient.isInventoryUpdateCommitSuccess(4004)).thenReturn(true);
+
+        assertThrows(OrderFailException.class, () -> orderService.insertOrder(order, session));
+
+        verify(kafkaTemplate, never()).send(eq("product_compensation"), any());
+        verify(catalogGrpcClient, times(1)).isInventoryUpdateCommitSuccess(4004);
+        verify(orderRepository, times(1)).updateStatus(argThat(status -> status.getStatus().equals("fail")));
+    }
 }

--- a/README.md
+++ b/README.md
@@ -21,3 +21,18 @@
 - [ ] 서비스 간의 세션 공유가 적절한가? 단일 장애 지점이 되지는 않는가?
 - [ ] 다른 서비스의 로직을 참고하는 상황에서 N+1 문제가 발생하지는 않는가? API 통신이기 때문에 호출량이 많아지면 엄청난 지연이 발생 가능하다.
 - [ ] 현재와 같이 SSR일 경우에 다른 서비스의 데이터들을 조합까지 한 후 뷰를 반환하게 되면 응답 속도가 SPA에 비해 느려지지 않는가? 그렇다면 뷰를 분리할 것인가?
+
+
+## Kafka 보상 트랜잭션 Chaos 테스트 (OrderService)
+- `ORDER_CHAOS_FORCE_PERSIST_FAILURE=true` : 재고 차감 이후 Order 저장 단계에서 의도적으로 실패를 발생시킨다.
+- `ORDER_CHAOS_SKIP_COMPENSATION_ON_PERSIST_FAILURE=true` : 저장 실패 시 Kafka 보상 메시지 발행을 생략한다(재고 불일치 재현용).
+- `ORDER_CHAOS_CHECK_INVENTORY_INCONSISTENCY_ON_FAILURE=true` : 실패 시 `isInventoryUpdateCommitSuccess`를 재조회하여 불일치 여부를 로그로 남긴다.
+
+예시:
+```bash
+ORDER_CHAOS_FORCE_PERSIST_FAILURE=true \
+ORDER_CHAOS_SKIP_COMPENSATION_ON_PERSIST_FAILURE=false \
+./gradlew :OrderService:bootRun
+```
+
+보상 비활성화 시에는 OrderService 로그에 `INVENTORY_INCONSISTENCY_DETECTED`가 출력되는지 확인한다.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.5.3' apply false
+    id 'org.springframework.boot' version '3.3.7' apply false
     id 'io.spring.dependency-management' version '1.1.7' apply false
     id 'com.google.protobuf' version '0.9.4' apply false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,10 @@ subprojects {
     dependencies {
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
     }
+
+    test {
+        useJUnitPlatform()
+    }
 }
 
 configure(subprojects.findAll { it.name != commonLibName }) {

--- a/deps.txt
+++ b/deps.txt
@@ -1,0 +1,367 @@
+
+> Task :CatalogService:dependencies
+
+------------------------------------------------------------
+Project ':CatalogService'
+------------------------------------------------------------
+
+testCompileClasspath - Compile classpath for source set 'test'.
++--- project :CommonLibrary
+|    +--- org.springframework.boot:spring-boot-starter-web -> 3.3.7
+|    |    +--- org.springframework.boot:spring-boot-starter:3.3.7
+|    |    |    +--- org.springframework.boot:spring-boot:3.3.7
+|    |    |    |    +--- org.springframework:spring-core:6.1.16
+|    |    |    |    |    \--- org.springframework:spring-jcl:6.1.16
+|    |    |    |    \--- org.springframework:spring-context:6.1.16
+|    |    |    |         +--- org.springframework:spring-aop:6.1.16
+|    |    |    |         |    +--- org.springframework:spring-beans:6.1.16
+|    |    |    |         |    |    \--- org.springframework:spring-core:6.1.16 (*)
+|    |    |    |         |    \--- org.springframework:spring-core:6.1.16 (*)
+|    |    |    |         +--- org.springframework:spring-beans:6.1.16 (*)
+|    |    |    |         +--- org.springframework:spring-core:6.1.16 (*)
+|    |    |    |         +--- org.springframework:spring-expression:6.1.16
+|    |    |    |         |    \--- org.springframework:spring-core:6.1.16 (*)
+|    |    |    |         \--- io.micrometer:micrometer-observation:1.12.12 -> 1.13.9
+|    |    |    |              \--- io.micrometer:micrometer-commons:1.13.9
+|    |    |    +--- org.springframework.boot:spring-boot-autoconfigure:3.3.7
+|    |    |    |    \--- org.springframework.boot:spring-boot:3.3.7 (*)
+|    |    |    +--- org.springframework.boot:spring-boot-starter-logging:3.3.7
+|    |    |    |    +--- ch.qos.logback:logback-classic:1.5.12
+|    |    |    |    |    +--- ch.qos.logback:logback-core:1.5.12
+|    |    |    |    |    \--- org.slf4j:slf4j-api:2.0.15 -> 2.0.16
+|    |    |    |    +--- org.apache.logging.log4j:log4j-to-slf4j:2.23.1
+|    |    |    |    |    +--- org.apache.logging.log4j:log4j-api:2.23.1
+|    |    |    |    |    \--- org.slf4j:slf4j-api:2.0.9 -> 2.0.16
+|    |    |    |    \--- org.slf4j:jul-to-slf4j:2.0.16
+|    |    |    |         \--- org.slf4j:slf4j-api:2.0.16
+|    |    |    +--- jakarta.annotation:jakarta.annotation-api:2.1.1
+|    |    |    +--- org.springframework:spring-core:6.1.16 (*)
+|    |    |    \--- org.yaml:snakeyaml:2.2
+|    |    +--- org.springframework.boot:spring-boot-starter-json:3.3.7
+|    |    |    +--- org.springframework.boot:spring-boot-starter:3.3.7 (*)
+|    |    |    +--- org.springframework:spring-web:6.1.16
+|    |    |    |    +--- org.springframework:spring-beans:6.1.16 (*)
+|    |    |    |    +--- org.springframework:spring-core:6.1.16 (*)
+|    |    |    |    \--- io.micrometer:micrometer-observation:1.12.12 -> 1.13.9 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.17.3
+|    |    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.17.3
+|    |    |    |    |    \--- com.fasterxml.jackson:jackson-bom:2.17.3
+|    |    |    |    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.17.3 (c)
+|    |    |    |    |         +--- com.fasterxml.jackson.core:jackson-core:2.17.3 (c)
+|    |    |    |    |         +--- com.fasterxml.jackson.core:jackson-databind:2.17.3 (c)
+|    |    |    |    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.17.3 (c)
+|    |    |    |    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.3 (c)
+|    |    |    |    |         \--- com.fasterxml.jackson.module:jackson-module-parameter-names:2.17.3 (c)
+|    |    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.17.3
+|    |    |    |    |    \--- com.fasterxml.jackson:jackson-bom:2.17.3 (*)
+|    |    |    |    \--- com.fasterxml.jackson:jackson-bom:2.17.3 (*)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.17.3
+|    |    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.17.3 (*)
+|    |    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.17.3 (*)
+|    |    |    |    \--- com.fasterxml.jackson:jackson-bom:2.17.3 (*)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.3
+|    |    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.17.3 (*)
+|    |    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.17.3 (*)
+|    |    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.17.3 (*)
+|    |    |    |    \--- com.fasterxml.jackson:jackson-bom:2.17.3 (*)
+|    |    |    \--- com.fasterxml.jackson.module:jackson-module-parameter-names:2.17.3
+|    |    |         +--- com.fasterxml.jackson.core:jackson-core:2.17.3 (*)
+|    |    |         +--- com.fasterxml.jackson.core:jackson-databind:2.17.3 (*)
+|    |    |         \--- com.fasterxml.jackson:jackson-bom:2.17.3 (*)
+|    |    +--- org.springframework.boot:spring-boot-starter-tomcat:3.3.7
+|    |    |    +--- jakarta.annotation:jakarta.annotation-api:2.1.1
+|    |    |    +--- org.apache.tomcat.embed:tomcat-embed-core:10.1.34
+|    |    |    |    \--- org.apache.tomcat:tomcat-annotations-api:10.1.34
+|    |    |    +--- org.apache.tomcat.embed:tomcat-embed-el:10.1.34
+|    |    |    \--- org.apache.tomcat.embed:tomcat-embed-websocket:10.1.34
+|    |    |         \--- org.apache.tomcat.embed:tomcat-embed-core:10.1.34 (*)
+|    |    +--- org.springframework:spring-web:6.1.16 (*)
+|    |    \--- org.springframework:spring-webmvc:6.1.16
+|    |         +--- org.springframework:spring-aop:6.1.16 (*)
+|    |         +--- org.springframework:spring-beans:6.1.16 (*)
+|    |         +--- org.springframework:spring-context:6.1.16 (*)
+|    |         +--- org.springframework:spring-core:6.1.16 (*)
+|    |         +--- org.springframework:spring-expression:6.1.16 (*)
+|    |         \--- org.springframework:spring-web:6.1.16 (*)
+|    +--- org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4
+|    |    +--- org.springframework.boot:spring-boot-starter:3.4.0 -> 3.3.7 (*)
+|    |    +--- org.springframework.boot:spring-boot-starter-jdbc:3.4.0 -> 3.3.7
+|    |    |    +--- org.springframework.boot:spring-boot-starter:3.3.7 (*)
+|    |    |    +--- com.zaxxer:HikariCP:5.1.0
+|    |    |    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    |    \--- org.springframework:spring-jdbc:6.1.16
+|    |    |         +--- org.springframework:spring-beans:6.1.16 (*)
+|    |    |         +--- org.springframework:spring-core:6.1.16 (*)
+|    |    |         \--- org.springframework:spring-tx:6.1.16
+|    |    |              +--- org.springframework:spring-beans:6.1.16 (*)
+|    |    |              \--- org.springframework:spring-core:6.1.16 (*)
+|    |    +--- org.mybatis.spring.boot:mybatis-spring-boot-autoconfigure:3.0.4
+|    |    |    \--- org.springframework.boot:spring-boot-autoconfigure:3.4.0 -> 3.3.7 (*)
+|    |    +--- org.mybatis:mybatis:3.5.17
+|    |    \--- org.mybatis:mybatis-spring:3.0.4
+|    +--- org.apache.tomcat.embed:tomcat-embed-jasper -> 10.1.34
+|    |    +--- org.apache.tomcat.embed:tomcat-embed-core:10.1.34 (*)
+|    |    +--- org.apache.tomcat.embed:tomcat-embed-el:10.1.34
+|    |    \--- org.eclipse.jdt:ecj:3.33.0
+|    +--- jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api -> 3.0.2
+|    |    +--- jakarta.servlet:jakarta.servlet-api:6.0.0
+|    |    \--- jakarta.el:jakarta.el-api:5.0.0
+|    +--- org.glassfish.web:jakarta.servlet.jsp.jstl -> 3.0.1
+|    +--- org.hsqldb:hsqldb:2.7.3
+|    +--- org.springframework.session:spring-session-data-redis -> 3.3.5
+|    |    +--- org.springframework.session:spring-session-core:3.3.5
+|    |    |    \--- org.springframework:spring-jcl:6.1.16
+|    |    \--- org.springframework.data:spring-data-redis:3.3.7
+|    |         +--- org.springframework.data:spring-data-keyvalue:3.3.7
+|    |         |    +--- org.springframework.data:spring-data-commons:3.3.7
+|    |         |    |    +--- org.springframework:spring-core:6.1.16 (*)
+|    |         |    |    +--- org.springframework:spring-beans:6.1.16 (*)
+|    |         |    |    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
+|    |         |    +--- org.springframework:spring-context:6.1.16 (*)
+|    |         |    +--- org.springframework:spring-tx:6.1.16 (*)
+|    |         |    \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
+|    |         +--- org.springframework:spring-tx:6.1.16 (*)
+|    |         +--- org.springframework:spring-oxm:6.1.16
+|    |         |    +--- org.springframework:spring-beans:6.1.16 (*)
+|    |         |    \--- org.springframework:spring-core:6.1.16 (*)
+|    |         +--- org.springframework:spring-aop:6.1.16 (*)
+|    |         +--- org.springframework:spring-context-support:6.1.16
+|    |         |    +--- org.springframework:spring-beans:6.1.16 (*)
+|    |         |    +--- org.springframework:spring-context:6.1.16 (*)
+|    |         |    \--- org.springframework:spring-core:6.1.16 (*)
+|    |         \--- org.slf4j:slf4j-api:2.0.2 -> 2.0.16
+|    +--- org.springframework.boot:spring-boot-starter-data-redis -> 3.3.7
+|    |    +--- org.springframework.boot:spring-boot-starter:3.3.7 (*)
+|    |    +--- io.lettuce:lettuce-core:6.3.2.RELEASE
+|    |    |    +--- io.netty:netty-common:4.1.107.Final -> 4.1.116.Final
+|    |    |    +--- io.netty:netty-handler:4.1.107.Final -> 4.1.116.Final
+|    |    |    |    +--- io.netty:netty-common:4.1.116.Final
+|    |    |    |    +--- io.netty:netty-resolver:4.1.116.Final
+|    |    |    |    |    \--- io.netty:netty-common:4.1.116.Final
+|    |    |    |    +--- io.netty:netty-buffer:4.1.116.Final
+|    |    |    |    |    \--- io.netty:netty-common:4.1.116.Final
+|    |    |    |    +--- io.netty:netty-transport:4.1.116.Final
+|    |    |    |    |    +--- io.netty:netty-common:4.1.116.Final
+|    |    |    |    |    +--- io.netty:netty-buffer:4.1.116.Final (*)
+|    |    |    |    |    \--- io.netty:netty-resolver:4.1.116.Final (*)
+|    |    |    |    +--- io.netty:netty-transport-native-unix-common:4.1.116.Final
+|    |    |    |    |    +--- io.netty:netty-common:4.1.116.Final
+|    |    |    |    |    +--- io.netty:netty-buffer:4.1.116.Final (*)
+|    |    |    |    |    \--- io.netty:netty-transport:4.1.116.Final (*)
+|    |    |    |    \--- io.netty:netty-codec:4.1.116.Final
+|    |    |    |         +--- io.netty:netty-common:4.1.116.Final
+|    |    |    |         +--- io.netty:netty-buffer:4.1.116.Final (*)
+|    |    |    |         \--- io.netty:netty-transport:4.1.116.Final (*)
+|    |    |    +--- io.netty:netty-transport:4.1.107.Final -> 4.1.116.Final (*)
+|    |    |    \--- io.projectreactor:reactor-core:3.6.4 -> 3.6.13
+|    |    |         \--- org.reactivestreams:reactive-streams:1.0.4
+|    |    \--- org.springframework.data:spring-data-redis:3.3.7 (*)
+|    +--- javax.annotation:javax.annotation-api:1.3.2
+|    +--- org.springframework.cloud:spring-cloud-starter-netflix-eureka-client:4.3.0
+|    |    +--- org.springframework.cloud:spring-cloud-starter:4.3.0
+|    |    |    +--- org.springframework.boot:spring-boot-starter:3.5.0 -> 3.3.7 (*)
+|    |    |    +--- org.springframework.cloud:spring-cloud-context:4.3.0
+|    |    |    |    \--- org.springframework.security:spring-security-crypto:6.5.0 -> 6.3.6
+|    |    |    +--- org.springframework.cloud:spring-cloud-commons:4.3.0
+|    |    |    |    \--- org.springframework.security:spring-security-crypto:6.5.0 -> 6.3.6
+|    |    |    \--- org.bouncycastle:bcprov-jdk18on:1.80
+|    |    +--- org.springframework.cloud:spring-cloud-netflix-eureka-client:4.3.0
+|    |    |    +--- com.netflix.eureka:eureka-client:2.0.4
+|    |    |    |    +--- com.thoughtworks.xstream:xstream:1.4.20
+|    |    |    |    |    \--- io.github.x-stream:mxparser:1.2.2
+|    |    |    |    |         \--- xmlpull:xmlpull:1.1.3.1
+|    |    |    |    +--- com.netflix.archaius:archaius-core:0.7.6
+|    |    |    |    +--- jakarta.ws.rs:jakarta.ws.rs-api:3.0.0 -> 3.1.0
+|    |    |    |    +--- jakarta.inject:jakarta.inject-api:2.0.1
+|    |    |    |    +--- jakarta.annotation:jakarta.annotation-api:2.1.0 -> 2.1.1
+|    |    |    |    +--- com.netflix.spectator:spectator-api:1.7.3
+|    |    |    |    +--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    |    |    +--- org.apache.httpcomponents:httpclient:4.5.3
+|    |    |    |    |    +--- org.apache.httpcomponents:httpcore:4.4.6 -> 4.4.16
+|    |    |    |    |    +--- commons-logging:commons-logging:1.2
+|    |    |    |    |    \--- commons-codec:commons-codec:1.9 -> 1.16.1
+|    |    |    |    +--- com.google.code.findbugs:jsr305:3.0.2
+|    |    |    |    +--- commons-configuration:commons-configuration:1.10
+|    |    |    |    |    +--- commons-lang:commons-lang:2.6
+|    |    |    |    |    \--- commons-logging:commons-logging:1.1.1 -> 1.2
+|    |    |    |    +--- com.github.vlsi.compactmap:compactmap:2.0
+|    |    |    |    |    \--- com.github.andrewoma.dexx:dexx-collections:0.2
+|    |    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5 -> 2.17.3 (*)
+|    |    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 -> 2.17.3 (*)
+|    |    |    |    \--- com.fasterxml.jackson.core:jackson-databind:2.13.5 -> 2.17.3 (*)
+|    |    |    \--- org.apache.httpcomponents.client5:httpclient5:5.4.4 -> 5.3.1
+|    |    |         +--- org.apache.httpcomponents.core5:httpcore5:5.2.4 -> 5.2.5
+|    |    |         +--- org.apache.httpcomponents.core5:httpcore5-h2:5.2.4 -> 5.2.5
+|    |    |         |    \--- org.apache.httpcomponents.core5:httpcore5:5.2.5
+|    |    |         \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.16
+|    |    +--- com.netflix.eureka:eureka-client:2.0.4 (*)
+|    |    \--- org.springframework.cloud:spring-cloud-starter-loadbalancer:4.3.0
+|    |         +--- org.springframework.cloud:spring-cloud-starter:4.3.0 (*)
+|    |         +--- org.springframework.cloud:spring-cloud-loadbalancer:4.3.0
+|    |         |    +--- org.springframework.cloud:spring-cloud-commons:4.3.0 (*)
+|    |         |    +--- org.springframework.cloud:spring-cloud-context:4.3.0 (*)
+|    |         |    +--- io.projectreactor:reactor-core:3.7.6 -> 3.6.13 (*)
+|    |         |    \--- io.projectreactor.addons:reactor-extra:3.5.2
+|    |         |         \--- io.projectreactor:reactor-core:3.5.20 -> 3.6.13 (*)
+|    |         +--- org.springframework.boot:spring-boot-starter-cache:3.5.0 -> 3.3.7
+|    |         |    +--- org.springframework.boot:spring-boot-starter:3.3.7 (*)
+|    |         |    \--- org.springframework:spring-context-support:6.1.16 (*)
+|    |         \--- com.stoyanr:evictor:1.0.0
+|    \--- net.devh:grpc-client-spring-boot-starter:3.1.0.RELEASE
+|         +--- net.devh:grpc-common-spring-boot:3.1.0.RELEASE
+|         |    +--- org.springframework.boot:spring-boot-starter:3.2.4 -> 3.3.7 (*)
+|         |    \--- io.grpc:grpc-core:1.63.0
+|         |         \--- io.grpc:grpc-api:1.63.0
+|         |              +--- com.google.code.findbugs:jsr305:3.0.2
+|         |              \--- com.google.errorprone:error_prone_annotations:2.23.0
+|         +--- org.springframework.boot:spring-boot-starter:3.2.4 -> 3.3.7 (*)
+|         +--- jakarta.validation:jakarta.validation-api:3.0.2
+|         +--- io.grpc:grpc-inprocess:1.63.0
+|         |    \--- io.grpc:grpc-api:1.63.0 (*)
+|         +--- io.grpc:grpc-netty-shaded:1.63.0
+|         |    \--- io.grpc:grpc-core:1.63.0 (*)
+|         +--- io.grpc:grpc-protobuf:1.63.0
+|         |    +--- io.grpc:grpc-api:1.63.0 (*)
+|         |    +--- com.google.code.findbugs:jsr305:3.0.2
+|         |    +--- com.google.protobuf:protobuf-java:3.25.1
+|         |    \--- com.google.api.grpc:proto-google-common-protos:2.29.0
+|         |         \--- com.google.protobuf:protobuf-java:3.25.1
+|         \--- io.grpc:grpc-stub:1.63.0
+|              +--- io.grpc:grpc-api:1.63.0 (*)
+|              \--- com.google.guava:guava:32.1.3-android
+|                   +--- com.google.guava:failureaccess:1.0.1
+|                   +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+|                   +--- com.google.code.findbugs:jsr305:3.0.2
+|                   +--- org.checkerframework:checker-qual:3.37.0
+|                   +--- com.google.errorprone:error_prone_annotations:2.21.1 -> 2.23.0
+|                   \--- com.google.j2objc:j2objc-annotations:2.8
++--- org.springframework.kafka:spring-kafka:3.3.7
+|    +--- org.springframework:spring-context:6.2.8 -> 6.1.16 (*)
+|    +--- org.springframework:spring-messaging:6.2.8 -> 6.1.16
+|    |    +--- org.springframework:spring-beans:6.1.16 (*)
+|    |    \--- org.springframework:spring-core:6.1.16 (*)
+|    +--- org.springframework:spring-tx:6.2.8 -> 6.1.16 (*)
+|    +--- org.springframework.retry:spring-retry:2.0.12 -> 2.0.11
+|    +--- org.apache.kafka:kafka-clients:3.8.1 -> 3.7.2
+|    \--- io.micrometer:micrometer-observation:1.14.8 -> 1.13.9 (*)
++--- net.devh:grpc-server-spring-boot-starter:3.1.0.RELEASE
+|    +--- net.devh:grpc-common-spring-boot:3.1.0.RELEASE (*)
+|    +--- org.springframework.boot:spring-boot-starter:3.2.4 -> 3.3.7 (*)
+|    +--- io.grpc:grpc-inprocess:1.63.0 (*)
+|    +--- io.grpc:grpc-netty-shaded:1.63.0 (*)
+|    +--- io.grpc:grpc-protobuf:1.63.0 (*)
+|    +--- io.grpc:grpc-stub:1.63.0 (*)
+|    +--- io.grpc:grpc-services:1.63.0
+|    |    \--- io.grpc:grpc-stub:1.63.0 (*)
+|    \--- io.grpc:grpc-api:1.63.0 (*)
++--- org.springframework.boot:spring-boot-starter-test -> 3.3.7
+|    +--- org.springframework.boot:spring-boot-starter:3.3.7 (*)
+|    +--- org.springframework.boot:spring-boot-test:3.3.7
+|    |    +--- org.springframework.boot:spring-boot:3.3.7 (*)
+|    |    \--- org.springframework:spring-test:6.1.16
+|    |         \--- org.springframework:spring-core:6.1.16 (*)
+|    +--- org.springframework.boot:spring-boot-test-autoconfigure:3.3.7
+|    |    +--- org.springframework.boot:spring-boot:3.3.7 (*)
+|    |    +--- org.springframework.boot:spring-boot-test:3.3.7 (*)
+|    |    \--- org.springframework.boot:spring-boot-autoconfigure:3.3.7 (*)
+|    +--- com.jayway.jsonpath:json-path:2.9.0
+|    +--- jakarta.xml.bind:jakarta.xml.bind-api:4.0.2
+|    |    \--- jakarta.activation:jakarta.activation-api:2.1.3
+|    +--- net.minidev:json-smart:2.5.1
+|    |    \--- net.minidev:accessors-smart:2.5.1
+|    |         \--- org.ow2.asm:asm:9.6
+|    +--- org.assertj:assertj-core:3.25.3
+|    |    \--- net.bytebuddy:byte-buddy:1.14.11 -> 1.14.19
+|    +--- org.awaitility:awaitility:4.2.2
+|    |    \--- org.hamcrest:hamcrest:2.1 -> 2.2
+|    +--- org.hamcrest:hamcrest:2.2
+|    +--- org.junit.jupiter:junit-jupiter:5.10.5
+|    |    +--- org.junit:junit-bom:5.10.5
+|    |    |    +--- org.junit.jupiter:junit-jupiter:5.10.5 (c)
+|    |    |    +--- org.junit.jupiter:junit-jupiter-api:5.10.5 (c)
+|    |    |    +--- org.junit.jupiter:junit-jupiter-params:5.10.5 (c)
+|    |    |    +--- org.junit.platform:junit-platform-commons:1.10.5 (c)
+|    |    |    +--- org.junit.platform:junit-platform-engine:1.10.5 (c)
+|    |    |    \--- org.junit.platform:junit-platform-launcher:1.10.5 (c)
+|    |    +--- org.junit.jupiter:junit-jupiter-api:5.10.5
+|    |    |    +--- org.junit:junit-bom:5.10.5 (*)
+|    |    |    +--- org.opentest4j:opentest4j:1.3.0
+|    |    |    +--- org.junit.platform:junit-platform-commons:1.10.5
+|    |    |    |    +--- org.junit:junit-bom:5.10.5 (*)
+|    |    |    |    \--- org.apiguardian:apiguardian-api:1.1.2
+|    |    |    \--- org.apiguardian:apiguardian-api:1.1.2
+|    |    \--- org.junit.jupiter:junit-jupiter-params:5.10.5
+|    |         +--- org.junit:junit-bom:5.10.5 (*)
+|    |         +--- org.junit.jupiter:junit-jupiter-api:5.10.5 (*)
+|    |         \--- org.apiguardian:apiguardian-api:1.1.2
+|    +--- org.mockito:mockito-core:5.11.0
+|    |    +--- net.bytebuddy:byte-buddy:1.14.12 -> 1.14.19
+|    |    \--- net.bytebuddy:byte-buddy-agent:1.14.12 -> 1.14.19
+|    +--- org.mockito:mockito-junit-jupiter:5.11.0
+|    |    \--- org.mockito:mockito-core:5.11.0 (*)
+|    +--- org.skyscreamer:jsonassert:1.5.3
+|    |    \--- com.vaadin.external.google:android-json:0.0.20131108.vaadin1
+|    +--- org.springframework:spring-core:6.1.16 (*)
+|    +--- org.springframework:spring-test:6.1.16 (*)
+|    \--- org.xmlunit:xmlunit-core:2.9.1
+\--- org.springframework.kafka:spring-kafka-test:3.3.7
+     +--- org.springframework:spring-context:6.2.8 -> 6.1.16 (*)
+     +--- org.springframework:spring-test:6.2.8 -> 6.1.16 (*)
+     +--- org.springframework.retry:spring-retry:2.0.12 -> 2.0.11
+     +--- org.apache.zookeeper:zookeeper:3.8.4
+     |    +--- org.apache.zookeeper:zookeeper-jute:3.8.4
+     |    |    \--- org.apache.yetus:audience-annotations:0.12.0
+     |    +--- org.apache.yetus:audience-annotations:0.12.0
+     |    +--- io.netty:netty-handler:4.1.105.Final -> 4.1.116.Final (*)
+     |    +--- io.netty:netty-transport-native-epoll:4.1.105.Final -> 4.1.116.Final
+     |    |    +--- io.netty:netty-common:4.1.116.Final
+     |    |    +--- io.netty:netty-buffer:4.1.116.Final (*)
+     |    |    +--- io.netty:netty-transport:4.1.116.Final (*)
+     |    |    +--- io.netty:netty-transport-native-unix-common:4.1.116.Final (*)
+     |    |    \--- io.netty:netty-transport-classes-epoll:4.1.116.Final
+     |    |         +--- io.netty:netty-common:4.1.116.Final
+     |    |         +--- io.netty:netty-buffer:4.1.116.Final (*)
+     |    |         +--- io.netty:netty-transport:4.1.116.Final (*)
+     |    |         \--- io.netty:netty-transport-native-unix-common:4.1.116.Final (*)
+     |    +--- org.slf4j:slf4j-api:1.7.30 -> 2.0.16
+     |    +--- ch.qos.logback:logback-core:1.2.13 -> 1.5.12
+     |    +--- ch.qos.logback:logback-classic:1.2.13 -> 1.5.12 (*)
+     |    \--- commons-io:commons-io:2.11.0
+     +--- org.apache.kafka:kafka-clients:3.8.1 -> 3.7.2
+     +--- org.apache.kafka:kafka-server:3.8.1 -> 3.7.2
+     +--- org.apache.kafka:kafka-metadata:3.8.1 -> 3.7.2
+     +--- org.apache.kafka:kafka-server-common:3.8.1 -> 3.7.2
+     |    \--- org.apache.kafka:kafka-clients:3.7.2
+     +--- org.apache.kafka:kafka-streams-test-utils:3.8.1 -> 3.7.2
+     |    +--- org.apache.kafka:kafka-streams:3.7.2
+     |    |    +--- org.apache.kafka:kafka-clients:3.7.2
+     |    |    \--- org.rocksdb:rocksdbjni:7.9.2
+     |    \--- org.apache.kafka:kafka-clients:3.7.2
+     +--- org.apache.kafka:kafka_2.13:3.8.1 -> 3.7.2
+     |    +--- org.apache.kafka:kafka-clients:3.7.2
+     |    \--- org.scala-lang:scala-library:2.13.12
+     +--- org.junit.jupiter:junit-jupiter-api:5.11.4 -> 5.10.5 (*)
+     \--- org.junit.platform:junit-platform-launcher:1.11.4 -> 1.10.5
+          +--- org.junit:junit-bom:5.10.5 (*)
+          +--- org.junit.platform:junit-platform-engine:1.10.5
+          |    +--- org.junit:junit-bom:5.10.5 (*)
+          |    +--- org.opentest4j:opentest4j:1.3.0
+          |    +--- org.junit.platform:junit-platform-commons:1.10.5 (*)
+          |    \--- org.apiguardian:apiguardian-api:1.1.2
+          \--- org.apiguardian:apiguardian-api:1.1.2
+
+(c) - A dependency constraint, not a dependency. The dependency affected by the constraint occurs elsewhere in the tree.
+(*) - Indicates repeated occurrences of a transitive dependency subtree. Gradle expands transitive dependency subtrees only once per project; repeat occurrences only display the root of the subtree, followed by this annotation.
+
+A web-based, searchable dependency report is available by adding the --scan option.
+
+[Incubating] Problems report is available at: file:///Users/kim-yejin/JPetStore6-microservices/build/reports/problems/problems-report.html
+
+Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.
+
+You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
+
+For more on this, please refer to https://docs.gradle.org/8.13/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
+
+BUILD SUCCESSFUL in 3s
+1 actionable task: 1 executed

--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -7,9 +7,6 @@ services:
       - "80:80"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
-#    # Linux에서 host.docker.internal 사용을 위해:
-#    extra_hosts:
-#      - "host.docker.internal:host-gateway"
   redis:
     image: redis:alpine
     container_name: redis
@@ -17,12 +14,68 @@ services:
       - "6379:6379"
     volumes:
       - redis-data:/data
-
   kafka:
     image: apache/kafka:4.0.0
     container_name: kafka
     ports:
       - "9092:9092"
+  kafdrop:
+    image: obsidiandynamics/kafdrop
+    container_name: kafdrop
+    ports:
+      - "9000:9000"
+    environment:
+      KAFKA_BROKERCONNECT: "kafka:9092"
+    depends_on:
+      - kafka
+
+  discoveryserver:
+    build:
+      context: ./../../DiscoveryServer
+    ports:
+      - "8761:8761"
+
+  gatewayservice:
+    build:
+      context: ./../../GatewayService
+    ports:
+      - "8080:8880"
+    environment:
+      - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://discoveryserver:8761/eureka
+    depends_on:
+      - discoveryserver
+
+  accountservice:
+    build:
+      context: ./../../AccountService
+    environment:
+      - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://discoveryserver:8761/eureka
+    depends_on:
+      - discoveryserver
+
+  cartservice:
+    build:
+      context: ./../../CartService
+    environment:
+      - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://discoveryserver:8761/eureka
+    depends_on:
+      - discoveryserver
+
+  catalogservice:
+    build:
+      context: ./../../CatalogService
+    environment:
+      - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://discoveryserver:8761/eureka
+    depends_on:
+      - discoveryserver
+
+  orderservice:
+    build:
+      context: ./../../OrderService
+    environment:
+      - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://discoveryserver:8761/eureka
+    depends_on:
+      - discoveryserver
 
 volumes:
   redis-data:

--- a/docker/local/nginx.conf
+++ b/docker/local/nginx.conf
@@ -18,33 +18,41 @@ http {
         listen 80;
         server_name localhost;
 
-        # /account/* → 로컬 8081
+        # Default: / -> gatewayservice
+        location / {
+            proxy_pass         http://gatewayservice:8880; # Corrected port and service name
+            proxy_set_header   Host $host;
+            proxy_set_header   X-Real-IP $remote_addr;
+            proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        # /account/* → accountservice
         location /account {
-            proxy_pass         http://host.docker.internal:8081;
+            proxy_pass         http://accountservice:8081; # Corrected port and service name
             proxy_set_header   Host $host;
             proxy_set_header   X-Real-IP $remote_addr;
             proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
-        # /cart/* → 로컬 8082
+        # /cart/* → cartservice
         location /cart {
-            proxy_pass         http://host.docker.internal:8082;
+            proxy_pass         http://cartservice:8082; # Corrected port and service name
             proxy_set_header   Host $host;
             proxy_set_header   X-Real-IP $remote_addr;
             proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
-        # /catalog/* → 로컬 8083
+        # /catalog/* → catalogservice
         location /catalog {
-            proxy_pass         http://host.docker.internal:8083;
+            proxy_pass         http://catalogservice:8083; # Corrected port and service name
             proxy_set_header   Host $host;
             proxy_set_header   X-Real-IP $remote_addr;
             proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
-        # /order/* → 로컬 8084
+        # /order/* → orderservice
         location /order {
-            proxy_pass         http://host.docker.internal:8084;
+            proxy_pass         http://orderservice:8084; # Corrected port and service name
             proxy_set_header   Host $host;
             proxy_set_header   X-Real-IP $remote_addr;
             proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
##   **[Title] Kafka 보상 이벤트 처리 병렬화 및 컨슈머 성능 최적화**


  **1. 배경 및 목적**
  * 주문 실패 시 발생하는 보상 이벤트(재고 복구)의 처리 속도를 높이기 위해 Kafka 컨슈머의 병렬 처리 구조를
     도입했습니다.
   * 대량의 보상 트랜잭션 발생 시 발생할 수 있는 컨슈머 지연을 최소화하기 위함입니다. 


  **3. 주요 변경 사항**
   * KafkaConsumerConfig 개선: 컨슈머 스레드 개수를 동적으로 조절할 수 있도록 kafka.consumer.concurrency
     프로퍼티를 추가했습니다. (기본값: 1)
   * 성능 검증 테스트 추가 (KafkaConcurrencyTest):
       * ```@EmbeddedKafka```를 활용해 멀티 파티션 환경에서의 병렬 처리 동작을 검증하는 통합 테스트를
         구축했습니다.
       * ```Mockito.doAnswer```를 활용하여 실제 I/O 지연(100ms) 상황을 시뮬레이션하고 처리 시간을 측정했습니다.


  4. 성능 검증 결과 (Local Test 기준)
  30개의 보상 이벤트를 100ms 지연 환경에서 처리했을 때의 결과입니다.
   * 단일 컨슈머 (Concurrency=1): 약 3,275 ms 소요 (순차 처리)
   * 멀티 컨슈머 (Concurrency=3): 약 1,329 ms 소요 (약 2.5배 성능 향상)
   * 로그 분석: 0-0-C-1, 0-1-C-1, 0-2-C-1 등 3개의 독립적인 스레드가 동시에 이벤트를 처리하는 것을
     확인했습니다.

```
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-2-C-1 | Total: 2
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-1-C-1 | Total: 2
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-0-C-1 | Total: 3
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-1-C-1 | Total: 5
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-2-C-1 | Total: 5
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-0-C-1 | Total: 6
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-1-C-1 | Total: 7
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-2-C-1 | Total: 8
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-0-C-1 | Total: 9
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-1-C-1 | Total: 10
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-2-C-1 | Total: 11
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-0-C-1 | Total: 12
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-1-C-1 | Total: 13
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-2-C-1 | Total: 14
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-0-C-1 | Total: 15
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-1-C-1 | Total: 16
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-2-C-1 | Total: 17
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-0-C-1 | Total: 18
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-2-C-1 | Total: 19
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-1-C-1 | Total: 20
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-0-C-1 | Total: 21
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-2-C-1 | Total: 22
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-1-C-1 | Total: 23
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-0-C-1 | Total: 24
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-2-C-1 | Total: 25
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-1-C-1 | Total: 26
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-0-C-1 | Total: 27
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-1-C-1 | Total: 29
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-2-C-1 | Total: 28
[CONSUMER] Thread: org.springframework.kafka.KafkaListenerEndpointContainer#0-2-C-1 | Total: 30
==========================================
Message Count: 30
Total Processing Time: 1329 ms
==========================================
```

  **5. 순서 보장 및 운영 고려사항**
   * 순서 보장 전략: 병렬 처리를 도입하더라도 동일 상품(itemId)에 대한 이벤트 순서가 뒤바뀌지 않도록,
     프로듀서 측에서 비즈니스 키(Key)를 사용하여 동일 파티션에 적재되도록 설계했습니다.
   * 자원 관리: 컨슈머 스레드 확장은 파티션 개수 및 DB 커넥션 풀(HikariCP)의 크기에 종속적이므로, 운영
     환경의 사양에 맞춰 concurrency 수치를 튜닝할 것을 권장합니다.



[#WIKI](https://github.com/Microservice-Dev/JPetStore6-microservices/wiki/Kafka-%EC%BB%A8%EC%8A%88%EB%A8%B8-%EB%B3%91%EB%A0%AC-%EC%B2%98%EB%A6%AC(Concurrency)-%EC%84%B1%EB%8A%A5-%EB%B6%84%EC%84%9D-%EB%B0%8F-%EC%B5%9C%EC%A0%81%ED%99%94)
